### PR TITLE
Create message coordinator for client

### DIFF
--- a/src/conduit/client/coordinator.py
+++ b/src/conduit/client/coordinator.py
@@ -209,3 +209,29 @@ class ClientMessageCoordinator:
         """Send error response to server."""
         response = JSONRPCError.from_error(error, request_id)
         await self.transport.send_to_server(response.to_wire())
+
+    # ================================
+    # Cancel requests
+    # ================================
+
+    async def cancel_request_from_server(self, request_id: str | int) -> None:
+        """Cancel a request from the server."""
+        result = self.server_manager.remove_request_from_server(request_id)
+        if result is None:
+            return
+        request, task = result
+        task.cancel()
+
+    # ================================
+    # Register handlers
+    # ================================
+
+    def register_request_handler(self, method: str, handler: RequestHandler) -> None:
+        """Register a request handler."""
+        self._request_handlers[method] = handler
+
+    def register_notification_handler(
+        self, method: str, handler: NotificationHandler
+    ) -> None:
+        """Register a notification handler."""
+        self._notification_handlers[method] = handler

--- a/src/conduit/client/coordinator.py
+++ b/src/conduit/client/coordinator.py
@@ -309,6 +309,7 @@ class ClientMessageCoordinator:
             return await asyncio.wait_for(future, timeout)
         except asyncio.TimeoutError:
             await self._handle_request_timeout(request_id, request)
+            raise
         finally:
             self.server_manager.remove_request_to_server(request_id)
 

--- a/src/conduit/client/coordinator.py
+++ b/src/conduit/client/coordinator.py
@@ -214,13 +214,13 @@ class ClientMessageCoordinator:
     # Cancel requests
     # ================================
 
-    async def cancel_request_from_server(self, request_id: str | int) -> None:
+    async def cancel_request_from_server(self, request_id: str | int) -> bool:
         """Cancel a request from the server."""
         result = self.server_manager.remove_request_from_server(request_id)
         if result is None:
-            return
+            return False
         request, task = result
-        task.cancel()
+        return task.cancel()
 
     # ================================
     # Register handlers

--- a/src/conduit/client/server_manager.py
+++ b/src/conduit/client/server_manager.py
@@ -1,0 +1,66 @@
+import asyncio
+from dataclasses import dataclass, field
+
+from conduit.protocol.base import INTERNAL_ERROR, Error, Request, Result
+from conduit.protocol.initialization import Implementation, ServerCapabilities
+from conduit.protocol.prompts import Prompt
+from conduit.protocol.resources import Resource, ResourceTemplate
+from conduit.protocol.tools import Tool
+
+
+@dataclass
+class ServerContext:
+    """Complete server state in one place."""
+
+    # Protocol state
+    capabilities: ServerCapabilities | None = None
+    info: Implementation | None = None
+    protocol_version: str | None = None
+    instructions: str | None = None
+    initialized: bool = False
+
+    # Domain state
+    tools: list[Tool] | None = None
+    resources: list[Resource] | None = None
+    resource_templates: list[ResourceTemplate] | None = None
+    prompts: list[Prompt] | None = None
+
+    # Request tracking
+    requests_from_server: dict[str | int, asyncio.Task[None]] = field(
+        default_factory=dict
+    )
+    requests_to_server: dict[
+        str | int, tuple[Request, asyncio.Future[Result | Error]]
+    ] = field(default_factory=dict)
+
+
+class ServerManager:
+    """Owns all server state and lifecycle."""
+
+    def __init__(self):
+        self._server_context = ServerContext()
+
+    def get_server_context(self) -> ServerContext:
+        """Get the server context."""
+        return self._server_context
+
+    def cleanup_requests(self) -> None:
+        """Clean up all request tracking when stopping.
+
+        Cancels in-flight requests the server is waiting on and resolves pending
+        requests the server is fulfilling.
+        """
+        context = self._server_context
+
+        for task in context.requests_from_server.values():
+            task.cancel()
+        context.requests_from_server.clear()
+
+        for _, future in context.requests_to_server.values():
+            if not future.done():
+                error = Error(
+                    code=INTERNAL_ERROR,
+                    message="Request failed. Client coordinator stopped.",
+                )
+                future.set_result(error)
+        context.requests_to_server.clear()

--- a/src/conduit/client/server_manager.py
+++ b/src/conduit/client/server_manager.py
@@ -49,7 +49,7 @@ class ServerManager:
     def cleanup_requests(self) -> None:
         """Clean up all request tracking when stopping.
 
-        Cancels in-flight requests the server is waiting on and resolves pending
+        Cancels work for requests the server is waiting on and resolves pending
         requests the server is fulfilling.
         """
         context = self._server_context
@@ -82,16 +82,16 @@ class ServerManager:
         context = self._server_context
         context.requests_from_server[request_id] = (request, task)
 
-    def remove_request_from_server(
+    def untrack_request_from_server(
         self, request_id: str | int
-    ) -> asyncio.Task[None] | None:
-        """Remove and return a request from server.
+    ) -> tuple[Request, asyncio.Task[None]] | None:
+        """Stop tracking a request from the server.
 
         Args:
             request_id: Request identifier to remove
 
         Returns:
-            The task if found, None otherwise
+            Tuple of (request, task) if found, None otherwise
         """
         context = self._server_context
         return context.requests_from_server.pop(request_id, None)
@@ -112,10 +112,10 @@ class ServerManager:
         context = self._server_context
         context.requests_to_server[request_id] = (request, future)
 
-    def remove_request_to_server(
+    def untrack_request_to_server(
         self, request_id: str
     ) -> tuple[Request, asyncio.Future[Result | Error]] | None:
-        """Remove and return a pending request to server.
+        """Stop tracking a request to the server.
 
         Args:
             request_id: Request identifier to remove

--- a/src/conduit/client/server_manager.py
+++ b/src/conduit/client/server_manager.py
@@ -125,3 +125,34 @@ class ServerManager:
         """
         context = self._server_context
         return context.requests_to_server.pop(request_id, None)
+
+    def get_request_to_server(
+        self, request_id: str | int
+    ) -> tuple[Request, asyncio.Future[Result | Error]] | None:
+        """Get a pending request to the server.
+
+        Args:
+            request_id: Request identifier to get
+
+        Returns:
+            Tuple of (request, future) if found, None otherwise
+        """
+        context = self._server_context
+        return context.requests_to_server.get(request_id, None)
+
+    def resolve_request_to_server(
+        self, request_id: str | int, result_or_error: Result | Error
+    ) -> None:
+        """Resolve a pending request to the server.
+
+        Sets the future and clears the request from the server context.
+
+        Args:
+            request_id: Request identifier to resolve
+            result_or_error: Result or error to resolve the request with
+        """
+        context = self._server_context
+        request_future_tuple = context.requests_to_server.pop(request_id, None)
+        if request_future_tuple:
+            request, future = request_future_tuple
+            future.set_result(result_or_error)

--- a/src/conduit/client/server_manager.py
+++ b/src/conduit/client/server_manager.py
@@ -7,6 +7,8 @@ from conduit.protocol.prompts import Prompt
 from conduit.protocol.resources import Resource, ResourceTemplate
 from conduit.protocol.tools import Tool
 
+RequestID = str | int
+
 
 @dataclass
 class ServerContext:
@@ -26,11 +28,11 @@ class ServerContext:
     prompts: list[Prompt] | None = None
 
     # Request tracking
-    requests_from_server: dict[str | int, tuple[Request, asyncio.Task[None]]] = field(
+    requests_from_server: dict[RequestID, tuple[Request, asyncio.Task[None]]] = field(
         default_factory=dict
     )
     requests_to_server: dict[
-        str | int, tuple[Request, asyncio.Future[Result | Error]]
+        RequestID, tuple[Request, asyncio.Future[Result | Error]]
     ] = field(default_factory=dict)
 
 

--- a/src/conduit/server/client_manager.py
+++ b/src/conduit/server/client_manager.py
@@ -6,6 +6,8 @@ from conduit.protocol.initialization import ClientCapabilities, Implementation
 from conduit.protocol.logging import LoggingLevel
 from conduit.protocol.roots import Root
 
+RequestID = str | int
+
 
 @dataclass
 class ClientContext:
@@ -25,11 +27,11 @@ class ClientContext:
     subscriptions: set[str] = field(default_factory=set)
 
     # Request tracking
-    requests_from_client: dict[str | int, tuple[Request, asyncio.Task[None]]] = field(
+    requests_from_client: dict[RequestID, tuple[Request, asyncio.Task[None]]] = field(
         default_factory=dict
     )
     requests_to_client: dict[
-        str | int, tuple[Request, asyncio.Future[Result | Error]]
+        RequestID, tuple[Request, asyncio.Future[Result | Error]]
     ] = field(default_factory=dict)
 
 

--- a/src/conduit/server/client_manager.py
+++ b/src/conduit/server/client_manager.py
@@ -143,10 +143,10 @@ class ClientManager:
 
         context.requests_to_client[request_id] = (request, future)
 
-    def remove_request_to_client(
+    def untrack_request_to_client(
         self, client_id: str, request_id: str
     ) -> tuple[Request, asyncio.Future[Result | Error]] | None:
-        """Remove and return a pending request.
+        """Stop tracking a request to the client.
 
         Args:
             client_id: ID of the client
@@ -227,10 +227,10 @@ class ClientManager:
 
         context.requests_from_client[request_id] = (request, task)
 
-    def remove_request_from_client(
+    def untrack_request_from_client(
         self, client_id: str, request_id: str | int
     ) -> tuple[Request, asyncio.Task[None]] | None:
-        """Remove and return a request from client.
+        """Stop tracking a request from the client.
 
         Args:
             client_id: ID of the client

--- a/src/conduit/server/coordinator.py
+++ b/src/conduit/server/coordinator.py
@@ -85,10 +85,7 @@ class MessageCoordinator:
         self._message_loop_task.add_done_callback(self._on_message_loop_done)
 
     async def stop(self) -> None:
-        """Stop message processing and cancel in-flight requests.
-
-        Cancels the background message processing task and any in-flight
-        request handlers across all clients.
+        """Stop message processing and clean up all incoming and outgoing requests.
 
         Safe to call multiple times.
         """
@@ -129,16 +126,14 @@ class MessageCoordinator:
             print(f"Transport error: {e}")
 
     def _on_message_loop_done(self, task: asyncio.Task[None]) -> None:
-        """Clean up when message loop exits unexpectedly.
+        """Clean up when message loop task completes.
 
-        Called when the message loop task completes due to transport failure
-        or other unexpected errors (not normal stop() cancellation).
+        Called whenever the message loop task finishes - whether due to normal
+        completion, cancellation, or unexpected errors. Ensures proper cleanup
+        of coordinator state.
         """
-        # Clear task reference so running becomes False
         self._message_loop_task = None
 
-        # Clean up all client state - cancel in-flight requests and
-        # resolve pending requests with errors
         self.client_manager.cleanup_all_clients()
 
     # ================================

--- a/src/conduit/server/coordinator.py
+++ b/src/conduit/server/coordinator.py
@@ -197,7 +197,9 @@ class MessageCoordinator:
             name=f"handle_{request.method}_{client_id}_{request_id}",
         )
 
-        self.client_manager.track_request_from_client(client_id, request_id, task)
+        self.client_manager.track_request_from_client(
+            client_id, request_id, request, task
+        )
         task.add_done_callback(
             lambda t: self.client_manager.remove_request_from_client(
                 client_id, request_id
@@ -305,10 +307,11 @@ class MessageCoordinator:
             True if request was found and successfully cancelled, False if request
             not found or was already completed/cancelled.
         """
-        task = self.client_manager.remove_request_from_client(client_id, request_id)
-        if not task:
+        result = self.client_manager.remove_request_from_client(client_id, request_id)
+        if result is None:
             return False
 
+        request, task = result
         return task.cancel()
 
     # ================================

--- a/src/conduit/server/coordinator.py
+++ b/src/conduit/server/coordinator.py
@@ -6,6 +6,7 @@ the session focused on protocol logic rather than message processing.
 
 import asyncio
 import uuid
+from collections.abc import Coroutine
 from typing import Any, Awaitable, Callable, TypeVar
 
 from conduit.protocol.base import (
@@ -35,7 +36,7 @@ TNotification = TypeVar("TNotification", bound=Notification)
 
 # Handler signatures - separate for requests vs notifications
 RequestHandler = Callable[[str, TRequest], Awaitable[TResult | Error]]
-NotificationHandler = Callable[[str, TNotification], Awaitable[None]]
+NotificationHandler = Callable[[str, TNotification], Coroutine[Any, Any, None]]
 
 
 class MessageCoordinator:

--- a/src/conduit/server/coordinator.py
+++ b/src/conduit/server/coordinator.py
@@ -237,13 +237,6 @@ class MessageCoordinator:
             )
             await self._send_error(client_id, request_id, error)
 
-    async def _send_error(
-        self, client_id: str, request_id: str | int, error: Error
-    ) -> None:
-        """Send error response to client."""
-        response = JSONRPCError.from_error(error, request_id)
-        await self.transport.send_to_client(client_id, response.to_wire())
-
     # ================================
     # Handle notifications
     # ================================
@@ -432,3 +425,10 @@ class MessageCoordinator:
     def _should_disconnect_for_error(self, error: Error) -> bool:
         """Determine if a client should be disconnected for an error."""
         return error.code == PROTOCOL_VERSION_MISMATCH
+
+    async def _send_error(
+        self, client_id: str, request_id: str | int, error: Error
+    ) -> None:
+        """Send error response to client."""
+        response = JSONRPCError.from_error(error, request_id)
+        await self.transport.send_to_client(client_id, response.to_wire())

--- a/src/conduit/transport/client.py
+++ b/src/conduit/transport/client.py
@@ -1,0 +1,46 @@
+# src/conduit/transport/client.py
+
+from abc import ABC, abstractmethod
+from collections.abc import AsyncIterator
+from typing import Any
+
+
+class ClientTransport(ABC):
+    """Transport for client communicating with a single server.
+
+    Handles the 1:1 connection pattern where one client communicates
+    with one server. Focuses purely on message passing - server lifecycle
+    is managed by the session layer.
+    """
+
+    @property
+    @abstractmethod
+    def is_open(self) -> bool:
+        """True if client transport is open and connected to server."""
+        ...
+
+    @abstractmethod
+    async def send_to_server(self, message: dict[str, Any]) -> None:
+        """Send message to the server.
+
+        Args:
+            message: JSON-RPC message to send
+
+        Raises:
+            ConnectionError: If transport is closed or connection failed
+        """
+        ...
+
+    @abstractmethod
+    def server_messages(self) -> AsyncIterator[dict[str, Any]]:
+        """Stream of messages from the server.
+
+        Yields:
+            dict[str, Any]: Raw JSON-RPC message payload from server
+        """
+        ...
+
+    @abstractmethod
+    async def close(self) -> None:
+        """Close connection to server."""
+        ...

--- a/src/conduit/transport/client.py
+++ b/src/conduit/transport/client.py
@@ -20,7 +20,7 @@ class ClientTransport(ABC):
         ...
 
     @abstractmethod
-    async def send_to_server(self, message: dict[str, Any]) -> None:
+    async def send(self, message: dict[str, Any]) -> None:
         """Send message to the server.
 
         Args:

--- a/src/conduit/transport/server.py
+++ b/src/conduit/transport/server.py
@@ -22,7 +22,7 @@ class ServerTransport(Protocol):
     on message passing - client lifecycle is managed by the session layer.
     """
 
-    async def send_to_client(self, client_id: str, message: dict[str, Any]) -> None:
+    async def send(self, client_id: str, message: dict[str, Any]) -> None:
         """Send message to specific client.
 
         Args:

--- a/tests/client/coordinator/conftest.py
+++ b/tests/client/coordinator/conftest.py
@@ -1,0 +1,100 @@
+import asyncio
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+
+from conduit.client.coordinator import ClientMessageCoordinator
+from conduit.client.server_manager import ServerManager
+from conduit.transport.client import ClientTransport
+
+
+class MockClientTransport(ClientTransport):
+    """Mock transport for testing ClientMessageCoordinator."""
+
+    def __init__(self):
+        self.sent_messages: list[dict[str, Any]] = []
+        self.server_message_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+        self._is_open = True
+
+    @property
+    def is_open(self) -> bool:
+        return self._is_open
+
+    async def send_to_server(self, message: dict[str, Any]) -> None:
+        """Record sent messages for test assertions."""
+        self.sent_messages.append(message)
+
+    def server_messages(self) -> AsyncIterator[dict[str, Any]]:
+        """Yield messages from the queue."""
+        return self._server_message_iterator()
+
+    async def _server_message_iterator(self) -> AsyncIterator[dict[str, Any]]:
+        """Async iterator over server messages."""
+        while self._is_open:
+            try:
+                message = await asyncio.wait_for(
+                    self.server_message_queue.get(), timeout=0.01
+                )
+                yield message
+            except asyncio.TimeoutError:
+                if not self._is_open:
+                    break
+                continue
+            except asyncio.CancelledError:
+                break
+
+    async def close(self) -> None:
+        """Close the transport."""
+        self._is_open = False
+        # Clear the queue to help the iterator exit faster
+        while not self.server_message_queue.empty():
+            try:
+                self.server_message_queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+
+    # Test helpers
+    def add_server_message(self, message: dict[str, Any]) -> None:
+        """Add a message to the queue (for tests to simulate server messages)."""
+        self.server_message_queue.put_nowait(message)
+
+
+@pytest.fixture
+async def mock_transport():
+    """Mock ClientTransport for testing with automatic cleanup."""
+    transport = MockClientTransport()
+    yield transport
+    await transport.close()
+
+
+@pytest.fixture
+def server_manager():
+    """Fresh ServerManager for testing."""
+    return ServerManager()
+
+
+@pytest.fixture
+async def coordinator(mock_transport, server_manager):
+    """ClientMessageCoordinator with mock dependencies and automatic cleanup."""
+    coord = ClientMessageCoordinator(mock_transport, server_manager)
+    yield coord
+    # Cleanup - ensure coordinator is stopped
+    if coord.running:
+        await coord.stop()
+
+
+async def yield_to_event_loop(seconds: float = 0.01) -> None:
+    """Let the event loop process pending tasks and callbacks.
+
+    Args:
+        seconds: Small delay to ensure async operations settle.
+                Defaults to 10ms - enough for most async operations.
+    """
+    await asyncio.sleep(seconds)
+
+
+@pytest.fixture
+def yield_loop():
+    """Helper to yield to event loop in tests."""
+    return yield_to_event_loop

--- a/tests/client/coordinator/conftest.py
+++ b/tests/client/coordinator/conftest.py
@@ -21,7 +21,7 @@ class MockClientTransport(ClientTransport):
     def is_open(self) -> bool:
         return self._is_open
 
-    async def send_to_server(self, message: dict[str, Any]) -> None:
+    async def send(self, message: dict[str, Any]) -> None:
         """Record sent messages for test assertions."""
         self.sent_messages.append(message)
 

--- a/tests/client/coordinator/test_lifecycle.py
+++ b/tests/client/coordinator/test_lifecycle.py
@@ -1,0 +1,154 @@
+import asyncio
+
+import pytest
+
+from conduit.protocol.base import Error
+from conduit.protocol.common import PingRequest
+
+
+class TestClientMessageCoordinatorLifecycle:
+    async def test_start_is_idempotent(self, coordinator):
+        # Arrange
+        assert not coordinator.running
+
+        # Act - start multiple times
+        await coordinator.start()
+        assert coordinator.running
+
+        await coordinator.start()  # Should be safe to call again
+
+        # Assert - still running after multiple starts
+        assert coordinator.running
+
+        # Cleanup
+        await coordinator.stop()
+        assert not coordinator.running
+
+    async def test_start_requires_open_transport(self, coordinator, mock_transport):
+        # Arrange
+        await mock_transport.close()
+        assert not mock_transport.is_open
+
+        # Act & Assert
+        with pytest.raises(ConnectionError, match="transport is closed"):
+            await coordinator.start()
+
+    async def test_stop_is_idempotent(self, coordinator):
+        # Arrange
+        await coordinator.start()
+        assert coordinator.running
+
+        # Act - stop multiple times
+        await coordinator.stop()
+        assert not coordinator.running
+
+        await coordinator.stop()  # Should be safe to call again
+        assert not coordinator.running
+
+    async def test_stop_without_start_is_safe(self, coordinator):
+        # Arrange
+        assert not coordinator.running
+
+        # Act & Assert - should not raise
+        await coordinator.stop()
+        assert not coordinator.running
+
+    async def test_running_property_reflects_state(self, coordinator):
+        # Arrange
+        assert not coordinator.running
+
+        # Act & Assert
+        await coordinator.start()
+        assert coordinator.running
+
+        await coordinator.stop()
+        assert not coordinator.running
+
+    async def test_multiple_start_stop_cycles(self, coordinator):
+        # Arrange & Act - multiple cycles
+        for _ in range(3):
+            assert not coordinator.running
+            await coordinator.start()
+            assert coordinator.running
+            await coordinator.stop()
+            assert not coordinator.running
+
+    async def test_coordinator_can_be_restarted_after_stop(
+        self, coordinator, mock_transport, yield_loop
+    ):
+        """Coordinator can be stopped and restarted and still process messages."""
+        # Arrange
+        handled_messages = []
+
+        async def tracking_handler(payload):
+            handled_messages.append(payload)
+
+        coordinator._handle_server_message = tracking_handler
+
+        # Act - Start, process message, stop
+        await coordinator.start()
+        mock_transport.add_server_message(
+            {"jsonrpc": "2.0", "method": "test/before-stop"}
+        )
+        await yield_loop()
+        await coordinator.stop()
+
+        # Act - Restart and process another message
+        await coordinator.start()
+        mock_transport.add_server_message(
+            {"jsonrpc": "2.0", "method": "test/after-restart"}
+        )
+        await yield_loop()
+
+        # Assert - Both phases worked
+        assert len(handled_messages) == 2
+        assert handled_messages[0]["method"] == "test/before-stop"
+        assert handled_messages[1]["method"] == "test/after-restart"
+
+        # Cleanup
+        await coordinator.stop()
+
+    async def test_stop_cancels_all_server_requests(
+        self, coordinator, server_manager, yield_loop
+    ):
+        # Arrange
+        await coordinator.start()
+
+        # Create mock in-flight tasks for requests FROM server
+        task1 = asyncio.create_task(asyncio.sleep(10))
+        task2 = asyncio.create_task(asyncio.sleep(10))
+
+        # Create mock pending request futures for requests TO server
+        future1 = asyncio.Future()
+        future2 = asyncio.Future()
+
+        # Add requests to server context
+        context = server_manager.get_server_context()
+        context.requests_from_server["req1"] = task1
+        context.requests_from_server["req2"] = task2
+
+        ping_request = PingRequest()
+        context.requests_to_server["ping1"] = (ping_request, future1)
+        context.requests_to_server["ping2"] = (ping_request, future2)
+
+        # Act
+        await coordinator.stop()
+        await yield_loop()
+
+        # Assert - both types of requests are cancelled/resolved
+        for task in [task1, task2]:
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        assert task1.cancelled()
+        assert task2.cancelled()
+        assert future1.done()
+        assert future2.done()
+
+        # Verify futures were resolved with errors
+        result1 = future1.result()
+        result2 = future2.result()
+        assert isinstance(result1, Error)
+        assert isinstance(result2, Error)

--- a/tests/client/coordinator/test_lifecycle.py
+++ b/tests/client/coordinator/test_lifecycle.py
@@ -115,6 +115,8 @@ class TestClientMessageCoordinatorLifecycle:
         await coordinator.start()
 
         # Create mock in-flight tasks for requests FROM server
+        mock_request1 = PingRequest()
+        mock_request2 = PingRequest()
         task1 = asyncio.create_task(asyncio.sleep(10))
         task2 = asyncio.create_task(asyncio.sleep(10))
 
@@ -124,8 +126,8 @@ class TestClientMessageCoordinatorLifecycle:
 
         # Add requests to server context
         context = server_manager.get_server_context()
-        context.requests_from_server["req1"] = task1
-        context.requests_from_server["req2"] = task2
+        context.requests_from_server["req1"] = (mock_request1, task1)
+        context.requests_from_server["req2"] = (mock_request2, task2)
 
         ping_request = PingRequest()
         context.requests_to_server["ping1"] = (ping_request, future1)

--- a/tests/client/coordinator/test_message_sending.py
+++ b/tests/client/coordinator/test_message_sending.py
@@ -1,0 +1,254 @@
+import asyncio
+
+import pytest
+
+from conduit.protocol.base import PROTOCOL_VERSION, Error, Result
+from conduit.protocol.common import CancelledNotification, PingRequest
+from conduit.protocol.initialization import (
+    ClientCapabilities,
+    Implementation,
+    InitializeRequest,
+)
+
+
+class TestRequestSending:
+    async def test_starts_coordinator(self, coordinator, yield_loop):
+        # Arrange
+        request = PingRequest()
+        assert not coordinator.running
+
+        # Act
+        asyncio.create_task(coordinator.send_request(request))
+
+        # Give coordinator time to send the request
+        await yield_loop()
+
+        # Assert
+        assert coordinator.running
+
+    async def test_tracks_request_to_server_and_returns_result(
+        self, coordinator, mock_transport, server_manager, yield_loop
+    ):
+        # Arrange
+        request = PingRequest()
+
+        # Act
+        request_task = asyncio.create_task(coordinator.send_request(request))
+
+        # Give coordinator time to send the request
+        await yield_loop()
+
+        # Assert - request was sent to transport
+        sent_messages = mock_transport.sent_messages
+        assert len(sent_messages) == 1
+
+        sent_request = sent_messages[0]
+        assert sent_request["method"] == "ping"
+        request_id = sent_request["id"]
+
+        # Assert - request is tracked
+        assert server_manager.get_request_to_server(request_id) is not None
+
+        # Act - simulate server response
+        response_payload = {"jsonrpc": "2.0", "id": request_id, "result": {}}
+        mock_transport.add_server_message(response_payload)
+
+        # Assert - request completes successfully
+        result = await request_task
+        assert isinstance(result, Result)
+
+        # Assert - request tracking was cleaned up
+        assert server_manager.get_request_to_server(request_id) is None
+
+    async def test_returns_error_response_from_server(
+        self, coordinator, mock_transport, server_manager, yield_loop
+    ):
+        # Arrange
+        request = PingRequest()
+
+        # Act
+        request_task = asyncio.create_task(coordinator.send_request(request))
+
+        # Give coordinator time to send the request
+        await yield_loop()
+
+        # Assert - request was sent to transport
+        sent_messages = mock_transport.sent_messages
+        request_id = sent_messages[0]["id"]
+        assert len(sent_messages) == 1
+
+        # Assert - request is tracked
+        assert server_manager.get_request_to_server(request_id) is not None
+
+        # Act - simulate server error response
+        error_response = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {
+                "code": -32601,
+                "message": "Method not found",
+                "data": {"details": "Unknown method"},
+            },
+        }
+        mock_transport.add_server_message(error_response)
+
+        # Assert - error response returned as Error object
+        result = await request_task
+        assert isinstance(result, Error)
+        assert result.code == -32601
+        assert result.message == "Method not found"
+
+        # Assert - request tracking was cleaned up
+        assert server_manager.get_request_to_server(request_id) is None
+
+    async def test_timeout_does_not_cancel_initialization_request(
+        self, coordinator, mock_transport, yield_loop
+    ):
+        # Arrange
+        request = InitializeRequest(
+            protocol_version=PROTOCOL_VERSION,
+            client_capabilities=ClientCapabilities(),
+            client_info=Implementation(
+                name="test",
+                version="1.0.0",
+            ),
+        )
+
+        # Act & Assert
+        with pytest.raises(asyncio.TimeoutError):
+            await coordinator.send_request(request, timeout=0.02)
+
+        await yield_loop()
+
+        # Assert - Did not send cancellation notification
+        sent_messages = mock_transport.sent_messages
+        assert len(sent_messages) == 1
+
+        # Assert - original request was sent
+        initialize_message = sent_messages[0]
+        assert initialize_message["method"] == "initialize"
+
+    async def test_timeout_cancels_non_initialization_request(
+        self, coordinator, mock_transport, yield_loop
+    ):
+        # Arrange
+        request = PingRequest()
+
+        # Act & Assert
+        with pytest.raises(asyncio.TimeoutError):
+            await coordinator.send_request(request, timeout=0.02)
+
+        await yield_loop()
+
+        # Assert - two messages were sent
+        sent_messages = mock_transport.sent_messages
+        assert len(sent_messages) == 2
+
+        # Assert - original request was sent
+        ping_message = sent_messages[0]
+        assert ping_message["method"] == "ping"
+
+        # Assert - cancellation notification was sent
+        cancellation_msg = sent_messages[1]
+        assert cancellation_msg["method"] == "notifications/cancelled"
+        assert "timed out" in cancellation_msg["params"]["reason"]
+
+    async def test_raises_connection_error_when_transport_closed(
+        self, coordinator, mock_transport, yield_loop
+    ):
+        # Arrange
+        request = PingRequest()
+
+        # Close the transport
+        await mock_transport.close()
+        await yield_loop()
+
+        # Act & Assert - should raise ConnectionError
+        with pytest.raises(ConnectionError):
+            await coordinator.send_request(request)
+
+        # Assert - no messages were sent
+        sent_messages = mock_transport.sent_messages
+        assert len(sent_messages) == 0
+
+    async def test_cleans_up_tracking_when_transport_fails(
+        self, coordinator, mock_transport, server_manager
+    ):
+        # Arrange
+        request = PingRequest()
+
+        async def failing_send(message):
+            raise ConnectionError("Test network failure")
+
+        mock_transport.send_to_server = failing_send
+
+        # Act & Assert - should raise the transport error
+        with pytest.raises(ConnectionError, match="Test network failure"):
+            await coordinator.send_request(request, timeout=1.0)
+
+        # Assert
+        server_context = server_manager.get_server_context()
+        assert len(server_context.requests_to_server) == 0
+
+
+class TestNotificationSending:
+    async def test_starts_coordinator(self, coordinator):
+        # Arrange
+        notification = CancelledNotification(
+            request_id="test-123", reason="user cancelled"
+        )
+        assert not coordinator.running
+
+        # Act
+        await coordinator.send_notification(notification)
+
+        # Assert
+        assert coordinator.running
+
+    async def test_sends_successfully(self, coordinator, mock_transport):
+        # Arrange
+        notification = CancelledNotification(
+            request_id="test-123", reason="user cancelled"
+        )
+
+        # Act
+        await coordinator.send_notification(notification)
+
+        # Assert - notification was sent to transport
+        sent_messages = mock_transport.sent_messages
+        assert len(sent_messages) == 1
+        sent_notification = sent_messages[0]
+        assert sent_notification["method"] == "notifications/cancelled"
+
+    async def test_raises_connection_error_when_transport_closed(
+        self, coordinator, mock_transport
+    ):
+        # Arrange
+        notification = CancelledNotification(
+            request_id="test-123", reason="user cancelled"
+        )
+
+        # Act - close the transport
+        await mock_transport.close()
+
+        # Act & Assert
+        with pytest.raises(ConnectionError):
+            await coordinator.send_notification(notification)
+
+        # Assert
+        assert len(mock_transport.sent_messages) == 0
+
+    async def test_propagates_transport_send_error(self, coordinator, mock_transport):
+        # Arrange
+        notification = CancelledNotification(
+            request_id="test-123", reason="user cancelled"
+        )
+
+        async def failing_send(message):
+            raise ConnectionError("Network failure")
+
+        mock_transport.send_to_server = failing_send
+
+        # Act & Assert
+        with pytest.raises(ConnectionError, match="Network failure"):
+            await coordinator.send_notification(notification)

--- a/tests/client/coordinator/test_message_sending.py
+++ b/tests/client/coordinator/test_message_sending.py
@@ -180,7 +180,7 @@ class TestRequestSending:
         async def failing_send(message):
             raise ConnectionError("Test network failure")
 
-        mock_transport.send_to_server = failing_send
+        mock_transport.send = failing_send
 
         # Act & Assert - should raise the transport error
         with pytest.raises(ConnectionError, match="Test network failure"):
@@ -247,7 +247,7 @@ class TestNotificationSending:
         async def failing_send(message):
             raise ConnectionError("Network failure")
 
-        mock_transport.send_to_server = failing_send
+        mock_transport.send = failing_send
 
         # Act & Assert
         with pytest.raises(ConnectionError, match="Network failure"):

--- a/tests/client/coordinator/test_request_handling.py
+++ b/tests/client/coordinator/test_request_handling.py
@@ -1,13 +1,12 @@
 import asyncio
 
 from conduit.protocol.base import INTERNAL_ERROR, METHOD_NOT_FOUND
-from conduit.protocol.common import EmptyResult
-from conduit.protocol.jsonrpc import Request
-from conduit.protocol.resources import ReadResourceRequest, ReadResourceResult
+from conduit.protocol.common import EmptyResult, PingRequest
+from conduit.protocol.elicitation import ElicitRequest, ElicitResult
 
 
 class TestRequestHandling:
-    """Test request handling in MessageCoordinator."""
+    """Test request handling in ClientMessageCoordinator."""
 
     async def test_sends_success_on_valid_request(
         self, coordinator, mock_transport, yield_loop
@@ -16,8 +15,8 @@ class TestRequestHandling:
         # Arrange: Set up a simple request handler
         handled_requests = []
 
-        async def mock_handler(client_id: str, request: Request) -> EmptyResult:
-            handled_requests.append((client_id, request))
+        async def mock_handler(request: PingRequest) -> EmptyResult:
+            handled_requests.append(request)
             return EmptyResult()
 
         # Register the handler
@@ -34,32 +33,24 @@ class TestRequestHandling:
             "method": "ping",
         }
 
-        mock_transport.add_client_message("client-1", request_payload)
+        mock_transport.add_server_message(request_payload)
         await yield_loop()  # Let coordinator process the message
 
         # Assert: Handler was called correctly
         assert len(handled_requests) == 1
-        client_id, request = handled_requests[0]
-        assert client_id == "client-1"
+        request = handled_requests[0]
         assert request.method == "ping"
 
-        # Assert: Response was sent back to client
-        assert "client-1" in mock_transport.sent_messages
-        responses = mock_transport.sent_messages["client-1"]
-        assert len(responses) == 1
-
-        response = responses[0]
-        assert response["jsonrpc"] == "2.0"
-        assert response["id"] == "test-123"
+        # Assert: Response was sent back to server
+        assert len(mock_transport.sent_messages) == 1
+        response = mock_transport.sent_messages[0]
         assert response["result"] == {}
-
-        # Assert: Client was auto-registered
-        assert coordinator.client_manager.get_client("client-1") is not None
+        assert response["id"] == "test-123"
 
         # Assert: Request was tracked and cleaned up
-        await yield_loop()  # Let client manager clean up
-        client = coordinator.client_manager.get_client("client-1")
-        assert len(client.requests_from_client) == 0
+        await yield_loop()  # Let server manager clean up
+        context = coordinator.server_manager.get_server_context()
+        assert len(context.requests_from_server) == 0
 
     async def test_sends_error_on_parsing_failure_to_protocol(
         self, coordinator, mock_transport, yield_loop
@@ -68,52 +59,46 @@ class TestRequestHandling:
         handler_called = False
 
         async def should_not_be_called(
-            client_id: str, request: ReadResourceRequest
-        ) -> ReadResourceResult:
+            request: ElicitRequest,
+        ) -> ElicitResult:
             nonlocal handler_called
             handler_called = True
-            return ReadResourceResult(contents=[])
+            # This shouldn't be reached
+            return ElicitResult(action="accept", content={})
 
-        coordinator.register_request_handler("resources/read", should_not_be_called)
+        coordinator.register_request_handler("elicitation/create", should_not_be_called)
 
         # Start the coordinator (needed for transport setup)
         await coordinator.start()
         await yield_loop()
 
-        # Not a real MCP method
-        cant_parse_to_protocol = {
+        # Valid method but missing required URI parameter
+        invalid_elicitation_create = {
             "jsonrpc": "2.0",
             "id": "test-123",
-            "method": "resources/read",
+            "method": "elicitation/create",
             "params": {
-                # missing required "uri" field
+                # Missing required 'message' and 'requestedSchema' fields
                 "some_other_field": "value",
             },
         }
 
-        # Act: Send the non-existent MCP method payload through the transport
-        mock_transport.add_client_message("client-1", cant_parse_to_protocol)
+        # Act: Send the malformed ElicitRequest through the transport
+        mock_transport.add_server_message(invalid_elicitation_create)
         await yield_loop()
 
         # Assert: Handler was not called
         assert not handler_called
 
-        # Assert: Error response was sent back to client
-        assert "client-1" in mock_transport.sent_messages
-        responses = mock_transport.sent_messages["client-1"]
-        assert len(responses) == 1
-
-        response = responses[0]
-        assert response["jsonrpc"] == "2.0"
+        # Assert: Error response was sent back to server
+        assert len(mock_transport.sent_messages) == 1
+        response = mock_transport.sent_messages[0]
         assert "error" in response
         assert response["id"] == "test-123"
 
-        # Assert: Client was still auto-registered
-        assert coordinator.client_manager.get_client("client-1") is not None
-
         # Assert: No request tracking since parsing failed
-        client = coordinator.client_manager.get_client("client-1")
-        assert len(client.requests_from_client) == 0
+        context = coordinator.server_manager.get_server_context()
+        assert len(context.requests_from_server) == 0
 
     async def test_handler_exception_returns_internal_error(
         self, coordinator, mock_transport, yield_loop
@@ -121,7 +106,7 @@ class TestRequestHandling:
         """Test that handler exceptions return INTERNAL_ERROR responses."""
 
         # Arrange: Set up a handler that throws an exception
-        async def failing_handler(client_id: str, request: Request) -> EmptyResult:
+        async def failing_handler(request: PingRequest) -> EmptyResult:
             raise ValueError("Something went wrong in the handler")
 
         coordinator.register_request_handler("ping", failing_handler)
@@ -137,27 +122,22 @@ class TestRequestHandling:
             "method": "ping",
         }
 
-        mock_transport.add_client_message("client-1", request_payload)
+        mock_transport.add_server_message(request_payload)
         await yield_loop()
 
-        # Assert: Error response was sent back to client
-        assert "client-1" in mock_transport.sent_messages
-        responses = mock_transport.sent_messages["client-1"]
-        assert len(responses) == 1
-
-        response = responses[0]
-        assert response["jsonrpc"] == "2.0"
+        # Assert: Error response was sent back to server
+        assert len(mock_transport.sent_messages) == 1
+        response = mock_transport.sent_messages[0]
         assert response["id"] == "test-123"
         assert "error" in response
 
         error = response["error"]
         assert error["code"] == INTERNAL_ERROR
 
-        # Assert: Client was registered and request was tracked/cleaned up
-        await yield_loop()  # Let client manager clean up
-        assert coordinator.client_manager.get_client("client-1") is not None
-        client = coordinator.client_manager.get_client("client-1")
-        assert len(client.requests_from_client) == 0
+        # Assert: Request was tracked and cleaned up
+        await yield_loop()  # Let server manager clean up
+        context = coordinator.server_manager.get_server_context()
+        assert len(context.requests_from_server) == 0
 
     async def test_cancel_request_and_cleanup(
         self, coordinator, mock_transport, yield_loop
@@ -166,7 +146,7 @@ class TestRequestHandling:
         handler_started = asyncio.Event()
         handler_cancelled = False
 
-        async def slow_handler(client_id: str, request: Request) -> EmptyResult:
+        async def slow_handler(request: PingRequest) -> EmptyResult:
             nonlocal handler_cancelled
             handler_started.set()  # Signal that handler has started
             try:
@@ -189,18 +169,18 @@ class TestRequestHandling:
             "method": "ping",
         }
 
-        mock_transport.add_client_message("client-1", request_payload)
+        mock_transport.add_server_message(request_payload)
         await yield_loop()
 
         # Wait for handler to start
         await handler_started.wait()
 
         # Verify request is being tracked
-        client = coordinator.client_manager.get_client("client-1")
-        assert len(client.requests_from_client) == 1
+        context = coordinator.server_manager.get_server_context()
+        assert len(context.requests_from_server) == 1
 
-        # Cancel the request
-        await coordinator.cancel_request_from_client("client-1", "test-123")
+        # Cancel the request using the coordinator's cancel method
+        await coordinator.cancel_request_from_server("test-123")
 
         # Give time for cancellation to propagate
         await yield_loop()
@@ -209,14 +189,10 @@ class TestRequestHandling:
         assert handler_cancelled
 
         # Assert: Request was cleaned up from tracking
-        assert (
-            coordinator.client_manager.get_request_from_client("client-1", "test-123")
-            is None
-        )
-        assert len(client.requests_from_client) == 0
+        assert len(context.requests_from_server) == 0
 
         # Assert: No response was sent (cancelled before completion)
-        assert "client-1" not in mock_transport.sent_messages
+        assert len(mock_transport.sent_messages) == 0
 
     async def test_returns_method_not_found_on_unregistered_method(
         self, coordinator, mock_transport, yield_loop
@@ -232,15 +208,12 @@ class TestRequestHandling:
         }
 
         # Act: Send a ping request with no handler registered
-        mock_transport.add_client_message("client-1", request_payload)
+        mock_transport.add_server_message(request_payload)
         await yield_loop()
 
-        # Assert: Error response was sent back to client
-        assert "client-1" in mock_transport.sent_messages
-        responses = mock_transport.sent_messages["client-1"]
-        assert len(responses) == 1
-
-        response = responses[0]
+        # Assert: Error response was sent back to server
+        assert len(mock_transport.sent_messages) == 1
+        response = mock_transport.sent_messages[0]
 
         assert response["id"] == "test-123"
         assert "error" in response

--- a/tests/client/coordinator/test_response_handling.py
+++ b/tests/client/coordinator/test_response_handling.py
@@ -1,0 +1,87 @@
+import asyncio
+
+from conduit.protocol.base import Error, Result
+from conduit.protocol.common import EmptyResult, PingRequest
+from conduit.protocol.tools import ListToolsRequest
+
+
+class TestResponseHandling:
+    async def test_resolves_pending_request_with_result(self, coordinator, yield_loop):
+        """Test that successful responses are parsed and resolved correctly."""
+        # Arrange
+        await coordinator.start()
+        request_id = "test-request-123"
+
+        # Set up a pending request
+        original_request = PingRequest()
+        future: asyncio.Future[Result | Error] = asyncio.Future()
+
+        coordinator.server_manager.track_request_to_server(
+            request_id, original_request, future
+        )
+
+        # Create a successful response payload
+        response_payload = {"jsonrpc": "2.0", "id": request_id, "result": {}}
+
+        # Act
+        await coordinator._handle_response(response_payload)
+        await yield_loop()
+
+        # Assert
+        assert future.done()
+        result = future.result()
+        assert isinstance(result, EmptyResult)
+
+        # Verify the request was cleaned up
+        assert coordinator.server_manager.get_request_to_server(request_id) is None
+
+    async def test_resolves_pending_request_with_error(self, coordinator, yield_loop):
+        """Test that error responses are parsed and resolved correctly."""
+        # Arrange
+        await coordinator.start()
+        request_id = "test-request-456"
+
+        # Set up a pending request
+        original_request = ListToolsRequest()
+        future: asyncio.Future[Result | Error] = asyncio.Future()
+
+        coordinator.server_manager.track_request_to_server(
+            request_id, original_request, future
+        )
+
+        # Create an error response payload
+        error_response = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {
+                "code": -32601,
+                "message": "Method not found",
+                "data": {"details": "Unknown method"},
+            },
+        }
+
+        # Act
+        await coordinator._handle_response(error_response)
+        await yield_loop()
+
+        # Assert
+        assert future.done()
+        result = future.result()
+        assert isinstance(result, Error)
+        assert result.code == -32601
+
+        # Verify the request was cleaned up
+        assert coordinator.server_manager.get_request_to_server(request_id) is None
+
+    async def test_ignores_response_for_unknown_request(self, coordinator, yield_loop):
+        """Test that responses for unknown requests are ignored gracefully."""
+        # Arrange
+        await coordinator.start()
+        request_id = "unknown-request-999"
+
+        # Create response payload
+        response_payload = {"jsonrpc": "2.0", "id": request_id, "result": {}}
+
+        # Act & Assert - should handle gracefully without raising
+        await coordinator._handle_response(response_payload)
+        await yield_loop()

--- a/tests/server/coordinator/conftest.py
+++ b/tests/server/coordinator/conftest.py
@@ -18,7 +18,7 @@ class MockServerTransport(ServerTransport):
         self._is_open = True
         self._should_raise_error = False
 
-    async def send_to_client(self, client_id: str, message: dict[str, Any]) -> None:
+    async def send(self, client_id: str, message: dict[str, Any]) -> None:
         if client_id not in self.sent_messages:
             self.sent_messages[client_id] = []
         self.sent_messages[client_id].append(message)

--- a/tests/server/coordinator/conftest.py
+++ b/tests/server/coordinator/conftest.py
@@ -16,7 +16,7 @@ class MockServerTransport(ServerTransport):
         self.sent_messages: dict[str, list[dict[str, Any]]] = {}
         self.client_message_queue: asyncio.Queue[ClientMessage] = asyncio.Queue()
         self._is_open = True
-        self._should_raise_error = False  # Add this flag
+        self._should_raise_error = False
 
     async def send_to_client(self, client_id: str, message: dict[str, Any]) -> None:
         if client_id not in self.sent_messages:

--- a/tests/server/coordinator/test_cancel_api.py
+++ b/tests/server/coordinator/test_cancel_api.py
@@ -7,7 +7,7 @@ class TestCancelAPI:
     """Test the public cancellation API methods."""
 
     async def test_cancel_request_from_client_success(
-        self, coordinator, client_manager, yield_loop
+        self, coordinator, client_manager
     ):
         """Test successfully cancelling a specific request from a client."""
         # Arrange: Set up a client with a tracked request
@@ -33,7 +33,6 @@ class TestCancelAPI:
 
         # Assert: Request was found and successfully cancelled
         assert result is True
-        await yield_loop()
         try:
             await mock_task
         except asyncio.CancelledError:
@@ -53,7 +52,7 @@ class TestCancelAPI:
 
         # Act: Try to cancel nonexistent request
         result = await coordinator.cancel_request_from_client(
-            client_id, "nonexistent-req"
+            client_id, "nonexistent-req-id"
         )
 
         # Assert: Returns False

--- a/tests/server/coordinator/test_lifecycle.py
+++ b/tests/server/coordinator/test_lifecycle.py
@@ -142,17 +142,18 @@ class TestMessageCoordinatorLifecycle:
         future2 = asyncio.Future()
 
         # Register clients with both in-flight and pending requests
-        client1 = client_manager.register_client("client1")
-        client2 = client_manager.register_client("client2")
+        client1_context = client_manager.register_client("client1")
+        client2_context = client_manager.register_client("client2")
         assert client_manager.client_count() == 2
 
         # In-flight requests (FROM clients TO server)
-        client1.requests_from_client["req1"] = (mock_request1, task1)
-        client2.requests_from_client["req2"] = (mock_request2, task2)
+        client1_context.requests_from_client["req1"] = (mock_request1, task1)
+        client2_context.requests_from_client["req2"] = (mock_request2, task2)
 
-        ping_request = PingRequest()
-        client1.requests_to_client["ping1"] = (ping_request, future1)
-        client2.requests_to_client["ping2"] = (ping_request, future2)
+        ping_to_client1 = PingRequest()
+        ping_to_client2 = PingRequest()
+        client1_context.requests_to_client["ping1"] = (ping_to_client1, future1)
+        client2_context.requests_to_client["ping2"] = (ping_to_client2, future2)
 
         # Act
         await coordinator.stop()

--- a/tests/server/coordinator/test_lifecycle.py
+++ b/tests/server/coordinator/test_lifecycle.py
@@ -132,6 +132,8 @@ class TestMessageCoordinatorLifecycle:
         await coordinator.start()
 
         # Create mock in-flight tasks for multiple clients
+        mock_request1 = PingRequest()
+        mock_request2 = PingRequest()
         task1 = asyncio.create_task(asyncio.sleep(10))
         task2 = asyncio.create_task(asyncio.sleep(10))
 
@@ -145,8 +147,8 @@ class TestMessageCoordinatorLifecycle:
         assert client_manager.client_count() == 2
 
         # In-flight requests (FROM clients TO server)
-        client1.requests_from_client["req1"] = task1
-        client2.requests_from_client["req2"] = task2
+        client1.requests_from_client["req1"] = (mock_request1, task1)
+        client2.requests_from_client["req2"] = (mock_request2, task2)
 
         ping_request = PingRequest()
         client1.requests_to_client["ping1"] = (ping_request, future1)

--- a/tests/server/coordinator/test_lifecycle.py
+++ b/tests/server/coordinator/test_lifecycle.py
@@ -64,21 +64,8 @@ class TestMessageCoordinatorLifecycle:
         await coordinator.stop()
         assert not coordinator.running
 
-    async def test_stop_cancels_message_loop_task(self, coordinator):
-        # Arrange
-        await coordinator.start()
-        assert coordinator.running
-
-        # Act
-        await coordinator.stop()
-
-        # Assert
-        assert not coordinator.running
-        # The message loop task should be cancelled/completed
-        # (We can't easily test the internal task without exposing it)
-
     async def test_coordinator_handles_transport_failure_gracefully(
-        self, coordinator, mock_transport
+        self, coordinator, mock_transport, yield_loop
     ):
         # Arrange
         await coordinator.start()
@@ -86,8 +73,7 @@ class TestMessageCoordinatorLifecycle:
         # Act - simulate transport failure
         await mock_transport.close()
 
-        # Give some time for the message loop to detect the failure
-        await asyncio.sleep(0.1)
+        await yield_loop()
 
         # Assert - coordinator should still be cleanly stoppable
         await coordinator.stop()

--- a/tests/server/coordinator/test_message_loop.py
+++ b/tests/server/coordinator/test_message_loop.py
@@ -115,6 +115,8 @@ class TestMessageLoop:
         await coordinator.start()
 
         # Create mock in-flight tasks and pending request futures
+        ping_from_client = PingRequest()
+        ping_to_client = PingRequest()
         task1 = asyncio.create_task(asyncio.sleep(10))
         future1 = asyncio.Future()
 
@@ -122,10 +124,14 @@ class TestMessageLoop:
         client_manager.register_client("client1")
         client_context = client_manager.get_client("client1")
 
-        client_context.requests_from_client["req1"] = (PingRequest(), task1)
-
-        ping_request = PingRequest()
-        client_context.requests_to_client["ping1"] = (ping_request, future1)
+        client_context.requests_from_client["ping_from_client"] = (
+            ping_from_client,
+            task1,
+        )
+        client_context.requests_to_client["ping_to_client"] = (
+            ping_to_client,
+            future1,
+        )
 
         assert client_manager.client_count() == 1
 
@@ -139,11 +145,10 @@ class TestMessageLoop:
         with pytest.raises(asyncio.CancelledError):
             await task1
 
-        # Be explicit about error resolution
+        # Verify error resolution
         assert future1.done()
         error = future1.result()
         assert isinstance(error, Error)
-        assert "disconnected" in error.message.lower()
 
     async def test_loop_respects_stop_call(
         self, coordinator, mock_transport, yield_loop

--- a/tests/server/coordinator/test_message_loop.py
+++ b/tests/server/coordinator/test_message_loop.py
@@ -122,7 +122,7 @@ class TestMessageLoop:
         client_manager.register_client("client1")
         client_context = client_manager.get_client("client1")
 
-        client_context.requests_from_client["req1"] = task1
+        client_context.requests_from_client["req1"] = (PingRequest(), task1)
 
         ping_request = PingRequest()
         client_context.requests_to_client["ping1"] = (ping_request, future1)

--- a/tests/server/coordinator/test_message_sending.py
+++ b/tests/server/coordinator/test_message_sending.py
@@ -14,9 +14,7 @@ class TestRequestSending:
         assert not coordinator.running
 
         # Act - send request in background
-        asyncio.create_task(
-            coordinator.send_request_to_client(client_id, request, timeout=1.0)
-        )
+        asyncio.create_task(coordinator.send_request(client_id, request, timeout=1.0))
 
         # Give coordinator time to send the request
         await yield_loop()
@@ -33,7 +31,7 @@ class TestRequestSending:
 
         # Act - send request in background
         request_task = asyncio.create_task(
-            coordinator.send_request_to_client(client_id, request, timeout=1.0)
+            coordinator.send_request(client_id, request, timeout=1.0)
         )
 
         # Give coordinator time to send the request
@@ -74,7 +72,7 @@ class TestRequestSending:
 
         # Act - send request in background
         request_task = asyncio.create_task(
-            coordinator.send_request_to_client(client_id, request, timeout=1.0)
+            coordinator.send_request(client_id, request, timeout=1.0)
         )
 
         # Give coordinator time to send the request
@@ -124,7 +122,7 @@ class TestRequestSending:
 
         # Act & Assert - timeout should raise
         with pytest.raises(asyncio.TimeoutError):
-            await coordinator.send_request_to_client(client_id, request, timeout=0.03)
+            await coordinator.send_request(client_id, request, timeout=0.03)
 
         # Give coordinator time to send cancellation
         await yield_loop()
@@ -155,7 +153,7 @@ class TestRequestSending:
 
         # Act & Assert
         with pytest.raises(ConnectionError):
-            await coordinator.send_request_to_client(client_id, request)
+            await coordinator.send_request(client_id, request)
 
         # Assert - no messages were sent
         sent_messages = mock_transport.sent_messages.get(client_id, [])
@@ -171,11 +169,11 @@ class TestRequestSending:
         async def failing_send(client_id, message):
             raise ConnectionError("Test network failure")
 
-        mock_transport.send_to_client = failing_send
+        mock_transport.send = failing_send
 
         # Act & Assert - should raise the transport error
         with pytest.raises(ConnectionError, match="Test network failure"):
-            await coordinator.send_request_to_client(client_id, request, timeout=1.0)
+            await coordinator.send_request(client_id, request, timeout=1.0)
 
         # Assert - request is no longer tracked
         client_context = client_manager.get_client(client_id)
@@ -193,7 +191,7 @@ class TestNotificationSending:
         assert not coordinator.running
 
         # Act
-        await coordinator.send_notification_to_client(client_id, notification)
+        await coordinator.send_notification(client_id, notification)
 
         # Assert
         assert coordinator.running
@@ -206,7 +204,7 @@ class TestNotificationSending:
         client_id = "test_client"
 
         # Act
-        await coordinator.send_notification_to_client(client_id, notification)
+        await coordinator.send_notification(client_id, notification)
 
         # Assert - notification was sent to transport
         sent_messages = mock_transport.sent_messages.get(client_id, [])
@@ -228,7 +226,7 @@ class TestNotificationSending:
 
         # Act & Assert - should raise ConnectionError
         with pytest.raises(ConnectionError):
-            await coordinator.send_notification_to_client(client_id, notification)
+            await coordinator.send_notification(client_id, notification)
 
         # Assert - no messages were sent
         sent_messages = mock_transport.sent_messages.get(client_id, [])
@@ -244,11 +242,11 @@ class TestNotificationSending:
         async def failing_send(client_id, message):
             raise ConnectionError("Test network failure")
 
-        mock_transport.send_to_client = failing_send
+        mock_transport.send = failing_send
 
         # Act & Assert - should raise the transport error
         with pytest.raises(ConnectionError, match="Test network failure"):
-            await coordinator.send_notification_to_client(client_id, notification)
+            await coordinator.send_notification(client_id, notification)
 
         # Assert - no messages were sent
         sent_messages = mock_transport.sent_messages.get(client_id, [])

--- a/tests/server/coordinator/test_message_sending.py
+++ b/tests/server/coordinator/test_message_sending.py
@@ -7,9 +7,7 @@ from conduit.protocol.common import CancelledNotification, PingRequest
 
 
 class TestRequestSending:
-    async def test_send_request_to_client_starts_coordinator(
-        self, coordinator, yield_loop
-    ):
+    async def test_starts_coordinator(self, coordinator, yield_loop):
         # Arrange
         request = PingRequest()
         client_id = "test_client"
@@ -23,14 +21,13 @@ class TestRequestSending:
         # Give coordinator time to send the request
         await yield_loop()
 
-        # Assert - coordinator was started
+        # Assert
         assert coordinator.running
 
-    async def test_send_request_completes_full_cycle(
+    async def test_tracks_request_to_client_and_returns_result(
         self, coordinator, mock_transport, client_manager, yield_loop
     ):
         # Arrange
-        await coordinator.start()
         request = PingRequest()
         client_id = "test_client"
 
@@ -47,13 +44,14 @@ class TestRequestSending:
         assert len(sent_messages) == 1
 
         sent_request = sent_messages[0]
+        request_id = sent_request["id"]
         assert sent_request["method"] == "ping"
 
         # Assert - client was registered and request is tracked
         assert client_manager.get_client(client_id) is not None
+        assert client_manager.get_request_to_client(client_id, request_id) is not None
 
         # Act - simulate client response
-        request_id = sent_request["id"]
         response_payload = {"jsonrpc": "2.0", "id": request_id, "result": {}}
         mock_transport.add_client_message(client_id, response_payload)
 
@@ -64,14 +62,13 @@ class TestRequestSending:
         result = await request_task
         assert isinstance(result, Result)
 
-        # Cleanup
-        await coordinator.stop()
+        # Assert - request is no longer tracked
+        assert client_manager.get_request_to_client(client_id, request_id) is None
 
-    async def test_send_request_returns_error_response_from_client(
+    async def test_returns_error_response_from_client(
         self, coordinator, mock_transport, client_manager, yield_loop
     ):
         # Arrange
-        await coordinator.start()
         request = PingRequest()
         client_id = "test_client"
 
@@ -88,10 +85,12 @@ class TestRequestSending:
         assert len(sent_messages) == 1
 
         sent_request = sent_messages[0]
-        assert sent_request["method"] == "ping"
+        request_id = sent_request["id"]
+
+        # Assert - request is tracked
+        assert client_manager.get_request_to_client(client_id, request_id) is not None
 
         # Act - simulate client error response
-        request_id = sent_request["id"]
         error_response = {
             "jsonrpc": "2.0",
             "id": request_id,
@@ -113,14 +112,13 @@ class TestRequestSending:
         assert result.message == "Method not found"
         assert result.data == {"details": "Unknown method"}
 
-        # Cleanup
-        await coordinator.stop()
+        # Assert - request is no longer tracked
+        assert client_manager.get_request_to_client(client_id, request_id) is None
 
-    async def test_send_request_timeout_raises_error_and_sends_cancellation(
+    async def test_timeout_raises_and_cancels(
         self, coordinator, mock_transport, yield_loop
     ):
         # Arrange
-        await coordinator.start()
         request = PingRequest()
         client_id = "test_client"
 
@@ -144,34 +142,29 @@ class TestRequestSending:
         assert cancellation_msg["method"] == "notifications/cancelled"
         assert "timed out" in cancellation_msg["params"]["reason"]
 
-        # Cleanup
-        await coordinator.stop()
-
-    async def test_send_request_raises_connection_error_when_transport_closed(
+    async def test_raises_connection_error_when_transport_closed(
         self, coordinator, mock_transport, yield_loop
     ):
         # Arrange
-        await coordinator.start()
         request = PingRequest()
         client_id = "test_client"
 
-        # Close the transport
+        # Act - close the transport
         await mock_transport.close()
         await yield_loop()
 
-        # Act & Assert - should raise ConnectionError
+        # Act & Assert
         with pytest.raises(ConnectionError):
-            await coordinator.send_request_to_client(client_id, request, timeout=1.0)
+            await coordinator.send_request_to_client(client_id, request)
 
         # Assert - no messages were sent
         sent_messages = mock_transport.sent_messages.get(client_id, [])
         assert len(sent_messages) == 0
 
-    async def test_send_request_cleans_up_tracking_when_transport_send_fails(
+    async def test_cleans_up_tracking_when_transport_send_fails(
         self, coordinator, mock_transport, client_manager
     ):
         # Arrange
-        await coordinator.start()
         request = PingRequest()
         client_id = "test_client"
 
@@ -184,18 +177,29 @@ class TestRequestSending:
         with pytest.raises(ConnectionError, match="Test network failure"):
             await coordinator.send_request_to_client(client_id, request, timeout=1.0)
 
-        # Assert - request tracking was cleaned up
+        # Assert - request is no longer tracked
         client_context = client_manager.get_client(client_id)
-        assert client_context is not None  # Client should still be registered
-        assert len(client_context.requests_to_client) == 0  # But no pending requests
+        assert client_context is not None
+        assert len(client_context.requests_to_client) == 0
 
 
 class TestNotificationSending:
-    async def test_send_notification_to_client_sends_message(
-        self, coordinator, mock_transport, yield_loop
-    ):
+    async def test_starts_coordinator(self, coordinator):
         # Arrange
-        await coordinator.start()
+        notification = CancelledNotification(
+            request_id="test-123", reason="user cancelled"
+        )
+        client_id = "test_client"
+        assert not coordinator.running
+
+        # Act
+        await coordinator.send_notification_to_client(client_id, notification)
+
+        # Assert
+        assert coordinator.running
+
+    async def test_sends_successfully(self, coordinator, mock_transport):
+        # Arrange
         notification = CancelledNotification(
             request_id="test-123", reason="user cancelled"
         )
@@ -207,25 +211,45 @@ class TestNotificationSending:
         # Assert - notification was sent to transport
         sent_messages = mock_transport.sent_messages.get(client_id, [])
         assert len(sent_messages) == 1
-
         sent_notification = sent_messages[0]
         assert sent_notification["method"] == "notifications/cancelled"
-        assert sent_notification["params"]["requestId"] == "test-123"
-        assert sent_notification["params"]["reason"] == "user cancelled"
 
-        # Cleanup
-        await coordinator.stop()
-
-    async def test_send_notification_to_client_starts_coordinator(self, coordinator):
+    async def test_raises_connection_error_when_transport_closed(
+        self, coordinator, mock_transport
+    ):
         # Arrange
         notification = CancelledNotification(
             request_id="test-123", reason="user cancelled"
         )
         client_id = "test_client"
-        assert not coordinator.running
 
-        # Act
-        await coordinator.send_notification_to_client(client_id, notification)
+        # Close the transport
+        await mock_transport.close()
 
-        # Assert - coordinator was started
-        assert coordinator.running
+        # Act & Assert - should raise ConnectionError
+        with pytest.raises(ConnectionError):
+            await coordinator.send_notification_to_client(client_id, notification)
+
+        # Assert - no messages were sent
+        sent_messages = mock_transport.sent_messages.get(client_id, [])
+        assert len(sent_messages) == 0
+
+    async def test_propagates_transport_send_error(self, coordinator, mock_transport):
+        # Arrange
+        notification = CancelledNotification(
+            request_id="test-123", reason="user cancelled"
+        )
+        client_id = "test_client"
+
+        async def failing_send(client_id, message):
+            raise ConnectionError("Test network failure")
+
+        mock_transport.send_to_client = failing_send
+
+        # Act & Assert - should raise the transport error
+        with pytest.raises(ConnectionError, match="Test network failure"):
+            await coordinator.send_notification_to_client(client_id, notification)
+
+        # Assert - no messages were sent
+        sent_messages = mock_transport.sent_messages.get(client_id, [])
+        assert len(sent_messages) == 0

--- a/tests/server/coordinator/test_request_handling.py
+++ b/tests/server/coordinator/test_request_handling.py
@@ -194,7 +194,7 @@ class TestRequestHandling:
         assert len(client.requests_from_client) == 1
 
         # Get the task and cancel it
-        task = coordinator.client_manager.get_request_from_client(
+        _, task = coordinator.client_manager.get_request_from_client(
             "client-1", "test-123"
         )
         assert task is not None

--- a/tests/server/coordinator/test_response_handling.py
+++ b/tests/server/coordinator/test_response_handling.py
@@ -2,6 +2,7 @@ import asyncio
 
 from conduit.protocol.base import Error, Result
 from conduit.protocol.common import EmptyResult, PingRequest
+from conduit.protocol.roots import ListRootsRequest
 
 
 class TestResponseHandling:
@@ -48,7 +49,7 @@ class TestResponseHandling:
         request_id = "test-request-456"
 
         # Set up a pending request
-        original_request = PingRequest()
+        original_request = ListRootsRequest()
         future: asyncio.Future[Result | Error] = asyncio.Future()
 
         client_manager.register_client(client_id)
@@ -79,19 +80,6 @@ class TestResponseHandling:
 
         # Verify the request was cleaned up
         assert client_manager.get_request_to_client(client_id, request_id) is None
-
-    async def test_ignores_response_missing_request_id(self, coordinator):
-        """Test that responses without request IDs are ignored gracefully."""
-        # Arrange
-        await coordinator.start()
-        client_id = "test_client"
-
-        # Create response payload without request ID
-        response_payload = {"jsonrpc": "2.0", "result": {}}
-
-        # Act & Assert - should handle gracefully without raising
-        await coordinator._handle_response(client_id, response_payload)
-        # If we get here, the test passed
 
     async def test_ignores_response_for_unknown_client(self, coordinator):
         """Test that responses from unknown clients are ignored gracefully."""

--- a/tests/server/test_client_manager.py
+++ b/tests/server/test_client_manager.py
@@ -43,7 +43,9 @@ class TestClientLifecycle:
 
         # Mock an in-flight request from the client
         processing_client_request = asyncio.create_task(asyncio.sleep(10))
-        manager.track_request_from_client(client_id, "req-1", processing_client_request)
+        manager.track_request_from_client(
+            client_id, "req-1", PingRequest(), processing_client_request
+        )
 
         # Mock a pending request to the client
         awaiting_client_response = asyncio.Future()
@@ -98,7 +100,9 @@ class TestClientLifecycle:
         # Client 1: Has both inbound and outbound requests
         processing_request_1 = asyncio.create_task(asyncio.sleep(10))
         awaiting_response_1 = asyncio.Future()
-        manager.track_request_from_client(client1_id, "req-1", processing_request_1)
+        manager.track_request_from_client(
+            client1_id, "req-1", PingRequest(), processing_request_1
+        )
         manager.track_request_to_client(
             client1_id, "req-2", PingRequest(), awaiting_response_1
         )
@@ -111,7 +115,9 @@ class TestClientLifecycle:
 
         # Client 3: Only has inbound request
         processing_request_3 = asyncio.create_task(asyncio.sleep(10))
-        manager.track_request_from_client(client3_id, "req-4", processing_request_3)
+        manager.track_request_from_client(
+            client3_id, "req-4", PingRequest(), processing_request_3
+        )
 
         # Verify setup
         assert manager.client_count() == 3


### PR DESCRIPTION
## What changed?

Added a `MessageCoordinator` for the client and tested it thoroughly.

## Why?

- Adopt the pattern we learned refactoring the server session.
- First step in moving away from `BaseSession` (can't use it for server so we're going to dump it)

## Impact

- Makes code base more consistent and provides a cleaner separation of concerns.

## Testing

Added extensive tests for the coordinator and improved existing ones for the server coordinator as well.

## Review notes

N/A

## Checklist

- [x] All new and old tests pass
- [x] Code follows our style guidelines
- [x] Documentation updated if needed
- [x] Breaking changes documented in commit messages

---
