### PR TITLE
Add logging

### DIFF
--- a/src/conduit/client/callbacks.py
+++ b/src/conduit/client/callbacks.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Awaitable, Callable
 
 from conduit.protocol.common import CancelledNotification, ProgressNotification
@@ -40,6 +41,7 @@ class CallbackManager:
         self.cancelled_handler: (
             Callable[[CancelledNotification], Awaitable[None]] | None
         ) = None
+        self.logger = logging.getLogger("conduit.client.callbacks")
 
     async def call_progress(
         self, server_id: str, notification: ProgressNotification
@@ -49,7 +51,11 @@ class CallbackManager:
             try:
                 await self.progress_handler(notification)
             except Exception as e:
-                print(f"Progress callback failed: {e}")
+                self.logger.warning(
+                    f"Progress callback failed: {e}. "
+                    f"Server: {server_id}. "
+                    f"Notification: {notification}"
+                )
 
     async def call_cancelled(
         self, server_id: str, notification: CancelledNotification
@@ -59,7 +65,11 @@ class CallbackManager:
             try:
                 await self.cancelled_handler(notification)
             except Exception as e:
-                print(f"Cancelled callback failed: {e}")
+                self.logger.warning(
+                    f"Cancelled callback failed: {e}. "
+                    f"Server: {server_id}. "
+                    f"Notification: {notification}"
+                )
 
     async def call_tools_changed(self, server_id: str, tools: list[Tool]) -> None:
         """Invokes tools changed callback. Catches and logs any errors."""
@@ -67,7 +77,11 @@ class CallbackManager:
             try:
                 await self.tools_changed_handler(tools)
             except Exception as e:
-                print(f"Tools changed callback failed: {e}")
+                self.logger.warning(
+                    f"Tools changed callback failed: {e}. "
+                    f"Server: {server_id}. "
+                    f"Tools: {tools}"
+                )
 
     async def call_resources_changed(
         self,
@@ -80,7 +94,12 @@ class CallbackManager:
             try:
                 await self.resources_changed_handler(resources, templates)
             except Exception as e:
-                print(f"Resources changed callback failed: {e}")
+                self.logger.warning(
+                    f"Resources changed callback failed: {e}. "
+                    f"Server: {server_id}. "
+                    f"Resources: {resources}. "
+                    f"Templates: {templates}"
+                )
 
     async def call_resource_updated(
         self, server_id: str, uri: str, result: ReadResourceResult
@@ -90,7 +109,12 @@ class CallbackManager:
             try:
                 await self.resource_updated_handler(uri, result)
             except Exception as e:
-                print(f"Resource updated callback failed: {e}")
+                self.logger.warning(
+                    f"Resource updated callback failed: {e}. "
+                    f"Server: {server_id}. "
+                    f"URI: {uri}. "
+                    f"Result: {result}"
+                )
 
     async def call_prompts_changed(self, server_id: str, prompts: list[Prompt]) -> None:
         """Invokes prompts changed callback. Catches and logs any errors."""
@@ -98,7 +122,11 @@ class CallbackManager:
             try:
                 await self.prompts_changed_handler(prompts)
             except Exception as e:
-                print(f"Prompts changed callback failed: {e}")
+                self.logger.warning(
+                    f"Prompts changed callback failed: {e}. "
+                    f"Server: {server_id}. "
+                    f"Prompts: {prompts}"
+                )
 
     async def call_logging_message(
         self, server_id: str, notification: LoggingMessageNotification
@@ -108,4 +136,8 @@ class CallbackManager:
             try:
                 await self.logging_message_handler(notification)
             except Exception as e:
-                print(f"Logging message callback failed: {e}")
+                self.logger.warning(
+                    f"Logging message callback failed: {e}. "
+                    f"Server: {server_id}. "
+                    f"Notification: {notification}"
+                )

--- a/src/conduit/client/protocol/elicitation.py
+++ b/src/conduit/client/protocol/elicitation.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Awaitable, Callable
 
 from conduit.protocol.elicitation import ElicitRequest, ElicitResult
@@ -14,6 +15,7 @@ class ElicitationManager:
         self.elicitation_handler: (
             Callable[[ElicitRequest], Awaitable[ElicitResult]] | None
         ) = None
+        self.logger = logging.getLogger("conduit.client.protocol.elicitation")
 
     async def handle_elicitation(
         self, server_id: str, request: ElicitRequest

--- a/src/conduit/client/protocol/roots.py
+++ b/src/conduit/client/protocol/roots.py
@@ -1,3 +1,4 @@
+import logging
 from copy import deepcopy
 
 from conduit.protocol.roots import ListRootsRequest, ListRootsResult, Root
@@ -7,6 +8,7 @@ class RootsManager:
     def __init__(self):
         self._server_roots: dict[str, list[Root]] = {}
         self._global_roots: list[Root] = []
+        self.logger = logging.getLogger(__name__)
 
     # ================================
     # Global root management
@@ -49,7 +51,9 @@ class RootsManager:
         if server_id in self._server_roots:
             for root in self._server_roots[server_id]:
                 if root.uri in roots_by_uri:
-                    print(f"Server {server_id} overriding global root '{root.uri}'")
+                    self.logger.warning(
+                        f"Server {server_id} overriding global root '{root.uri}'"
+                    )
                 roots_by_uri[root.uri] = root
 
         return list(roots_by_uri.values())

--- a/src/conduit/client/protocol/roots.py
+++ b/src/conduit/client/protocol/roots.py
@@ -8,7 +8,7 @@ class RootsManager:
     def __init__(self):
         self._server_roots: dict[str, list[Root]] = {}
         self._global_roots: list[Root] = []
-        self.logger = logging.getLogger(__name__)
+        self.logger = logging.getLogger("conduit.client.protocol.roots")
 
     # ================================
     # Global root management

--- a/src/conduit/client/protocol/sampling.py
+++ b/src/conduit/client/protocol/sampling.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Awaitable, Callable
 
 from conduit.protocol.sampling import CreateMessageRequest, CreateMessageResult
@@ -14,6 +15,7 @@ class SamplingManager:
         self.sampling_handler: (
             Callable[[CreateMessageRequest], Awaitable[CreateMessageResult]] | None
         ) = None
+        self.logger = logging.getLogger("conduit.client.protocol.sampling")
 
     async def handle_create_message(
         self, server_id: str, request: CreateMessageRequest

--- a/src/conduit/client/session.py
+++ b/src/conduit/client/session.py
@@ -7,6 +7,8 @@ Key components:
 """
 
 import asyncio
+import logging
+import sys
 from dataclasses import dataclass
 from typing import Any, cast
 
@@ -106,6 +108,16 @@ class ClientSession:
         self._coordinator = MessageCoordinator(transport, self.server_manager)
         self._register_handlers()
 
+        # Configure logging if not already configured
+        if not logging.getLogger().handlers:
+            logging.basicConfig(
+                level=logging.INFO,
+                format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+                stream=sys.stderr,
+            )
+
+        self.logger = logging.getLogger("conduit.client.session")
+
     # ================================
     # Lifecycle
     # ================================
@@ -137,7 +149,9 @@ class ClientSession:
         try:
             await self.transport.disconnect_server(server_id)
         except Exception as e:
-            print(f"Transport error while disconnecting from server {server_id}: {e}")
+            self.logger.warning(
+                f"Transport error while disconnecting from server {server_id}: {e}"
+            )
 
     async def disconnect_all_servers(self) -> None:
         """Disconnects from all servers and cleans up all state."""

--- a/src/conduit/server/callbacks.py
+++ b/src/conduit/server/callbacks.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Awaitable, Callable
 
 from conduit.protocol.common import CancelledNotification, ProgressNotification
@@ -21,6 +22,7 @@ class CallbackManager:
         self.cancelled_handler: (
             Callable[[str, CancelledNotification], Awaitable[None]] | None
         ) = None
+        self.logger = logging.getLogger("conduit.server.callbacks")
 
     async def call_initialized(
         self, client_id: str, notification: InitializedNotification
@@ -30,7 +32,10 @@ class CallbackManager:
             try:
                 await self.initialized_handler(client_id, notification)
             except Exception as e:
-                print(f"Initialized callback failed for {client_id}: {e}")
+                self.logger.warning(
+                    f"Initialized callback failed for {client_id}: {e}. "
+                    f"Notification: {notification}"
+                )
 
     async def call_progress(
         self, client_id: str, notification: ProgressNotification
@@ -40,7 +45,10 @@ class CallbackManager:
             try:
                 await self.progress_handler(client_id, notification)
             except Exception as e:
-                print(f"Progress callback failed for {client_id}: {e}")
+                self.logger.warning(
+                    f"Progress callback failed for {client_id}: {e}. "
+                    f"Notification: {notification}"
+                )
 
     async def call_roots_changed(self, client_id: str, roots: list[Root]) -> None:
         """Invokes roots changed callback. Catches and logs any errors."""
@@ -48,7 +56,10 @@ class CallbackManager:
             try:
                 await self.roots_changed_handler(client_id, roots)
             except Exception as e:
-                print(f"Roots changed callback failed for {client_id}: {e}")
+                self.logger.warning(
+                    f"Roots changed callback failed for {client_id}: {e}. "
+                    f"Roots: {roots}"
+                )
 
     async def call_cancelled(
         self, client_id: str, notification: CancelledNotification
@@ -58,4 +69,7 @@ class CallbackManager:
             try:
                 await self.cancelled_handler(client_id, notification)
             except Exception as e:
-                print(f"Cancelled callback failed for {client_id}: {e}")
+                self.logger.warning(
+                    f"Cancelled callback failed for {client_id}: {e}. "
+                    f"Notification: {notification}"
+                )

--- a/src/conduit/server/protocol/completions.py
+++ b/src/conduit/server/protocol/completions.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Awaitable, Callable
 
 from conduit.protocol.completions import CompleteRequest, CompleteResult
@@ -14,6 +15,7 @@ class CompletionManager:
         self.completion_handler: (
             Callable[[str, CompleteRequest], Awaitable[CompleteResult]] | None
         ) = None
+        self.logger = logging.getLogger("conduit.server.protocol.completions")
 
     async def handle_complete(
         self, client_id: str, request: CompleteRequest

--- a/src/conduit/server/protocol/logging.py
+++ b/src/conduit/server/protocol/logging.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Awaitable, Callable
 
 from conduit.protocol.common import EmptyResult
@@ -17,6 +18,7 @@ class LoggingManager:
         self.level_change_handler: (
             Callable[[str, LoggingLevel], Awaitable[None]] | None
         ) = None
+        self.logger = logging.getLogger("conduit.server.protocol.logging")
 
     def get_client_level(self, client_id: str) -> LoggingLevel | None:
         """Get the current logging level for a specific client.
@@ -69,6 +71,9 @@ class LoggingManager:
             try:
                 await self.level_change_handler(client_id, request.level)
             except Exception as e:
-                print(f"Error in level change handler for {client_id}: {e}")
+                self.logger.warning(
+                    f"Error in level change handler for {client_id}: {e}. "
+                    f"Request: {request}"
+                )
 
         return EmptyResult()

--- a/src/conduit/server/protocol/prompts.py
+++ b/src/conduit/server/protocol/prompts.py
@@ -1,3 +1,4 @@
+import logging
 from copy import deepcopy
 from typing import Awaitable, Callable
 
@@ -22,7 +23,7 @@ class PromptManager:
     def __init__(self):
         self.global_prompts: dict[str, Prompt] = {}
         self.global_handlers: dict[str, PromptHandler] = {}
-
+        self.logger = logging.getLogger("conduit.server.protocol.prompts")
         self.client_prompts: dict[
             str, dict[str, Prompt]
         ] = {}  # client_id -> {prompt_name: prompt}
@@ -131,7 +132,9 @@ class PromptManager:
         if client_id in self.client_prompts:
             for name, prompt in self.client_prompts[client_id].items():
                 if name in prompts:
-                    print(f"Client {client_id} overriding global prompt '{name}'")
+                    self.logger.info(
+                        f"Client {client_id} overriding global prompt '{name}'"
+                    )
                 prompts[name] = prompt
 
         return prompts

--- a/src/conduit/server/protocol/resources.py
+++ b/src/conduit/server/protocol/resources.py
@@ -1,5 +1,6 @@
 """Client-aware resource manager for multi-client server sessions."""
 
+import logging
 import re
 from copy import deepcopy
 from typing import Awaitable, Callable
@@ -48,6 +49,7 @@ class ResourceManager:
 
         self.subscribe_handler: SubscriptionCallback | None = None
         self.unsubscribe_handler: SubscriptionCallback | None = None
+        self.logger = logging.getLogger("conduit.server.protocol.resources")
 
     # ===============================
     # Global resource management
@@ -179,7 +181,9 @@ class ResourceManager:
         if client_id in self.client_resources:
             for uri, resource in self.client_resources[client_id].items():
                 if uri in resources:
-                    print(f"Client {client_id} overriding global resource '{uri}'")
+                    self.logger.info(
+                        f"Client {client_id} overriding global resource '{uri}'"
+                    )
                 resources[uri] = resource
 
         return resources
@@ -201,7 +205,9 @@ class ResourceManager:
         if client_id in self.client_templates:
             for pattern, template in self.client_templates[client_id].items():
                 if pattern in templates:
-                    print(f"Client {client_id} overriding global template '{pattern}'")
+                    self.logger.info(
+                        f"Client {client_id} overriding global template '{pattern}'"
+                    )
                 templates[pattern] = template
 
         return templates
@@ -318,7 +324,9 @@ class ResourceManager:
             try:
                 await self.subscribe_handler(client_id, uri)
             except Exception as e:
-                print(f"Error in subscribe handler for {client_id}: {uri}: {e}")
+                self.logger.warning(
+                    f"Error in subscribe handler for {client_id}: {uri}: {e}"
+                )
 
         return EmptyResult()
 
@@ -349,7 +357,9 @@ class ResourceManager:
             try:
                 await self.unsubscribe_handler(client_id, uri)
             except Exception as e:
-                print(f"Error in unsubscribe handler for {client_id}: {uri}: {e}")
+                self.logger.warning(
+                    f"Error in unsubscribe handler for {client_id}: {uri}: {e}"
+                )
 
         return EmptyResult()
 

--- a/src/conduit/server/protocol/tools.py
+++ b/src/conduit/server/protocol/tools.py
@@ -1,5 +1,6 @@
 """Client-aware tool manager for multi-client server sessions."""
 
+import logging
 from copy import deepcopy
 from typing import Awaitable, Callable
 
@@ -31,6 +32,8 @@ class ToolManager:
         self.client_handlers: dict[
             str, dict[str, ToolHandler]
         ] = {}  # client_id -> {tool_name: handler}
+
+        self.logger = logging.getLogger("conduit.server.protocol.tools")
 
     # ================================
     # Global tool management
@@ -134,7 +137,9 @@ class ToolManager:
         if client_id in self.client_tools:
             for name, tool in self.client_tools[client_id].items():
                 if name in tools:
-                    print(f"Client {client_id} overriding global tool '{name}'")
+                    self.logger.info(
+                        f"Client {client_id} overriding global tool '{name}'"
+                    )
                 tools[name] = tool
 
         return tools


### PR DESCRIPTION
## What changed?

Added logging to client and server session. Each session manager gets a logger with a clear name e.g., `conduit.client.protocol.roots`.

Closes #4.

## Why?

We had print statements scattered before. That's neither robust nor configurable. Also, printing interferes with server communication over stdout (stdio transport).

## Impact

-Can build stdio transport comfortably.
- Set the stage for improved logging and debugging.

## Testing

N/A

## Review notes

N/A

## Checklist

- [x] All new and old tests pass
- [x] Code follows our style guidelines
- [x] Documentation updated if needed
- [x] Breaking changes documented in commit messages
