### PR TITLE
Add request context

### DIFF
--- a/src/conduit/server/protocol/logging.py
+++ b/src/conduit/server/protocol/logging.py
@@ -1,8 +1,11 @@
 import logging
-from typing import Awaitable, Callable
+from typing import TYPE_CHECKING, Awaitable, Callable
 
 from conduit.protocol.common import EmptyResult
 from conduit.protocol.logging import LoggingLevel, SetLevelRequest
+
+if TYPE_CHECKING:
+    from conduit.server.request_context import RequestContext
 
 
 class LoggingManager:
@@ -52,19 +55,20 @@ class LoggingManager:
         self._client_log_levels.pop(client_id, None)
 
     async def handle_set_level(
-        self, client_id: str, request: SetLevelRequest
+        self, context: "RequestContext", request: SetLevelRequest
     ) -> EmptyResult:
         """Sets the MCP protocol logging level for specific client.
 
         Sets the logging level for a client and calls the level change handler.
 
         Args:
-            client_id: The client's unique identifier.
+            context: Rich request context with client state and helpers
             request: The request containing the new logging level.
 
         Returns:
             EmptyResult: Empty result indicating success.
         """
+        client_id = context.client_id
         self._client_log_levels[client_id] = request.level
 
         if self.level_change_handler:

--- a/src/conduit/server/protocol/resources.py
+++ b/src/conduit/server/protocol/resources.py
@@ -26,9 +26,7 @@ if TYPE_CHECKING:
 ResourceHandler = Callable[
     ["RequestContext", ReadResourceRequest], Awaitable[ReadResourceResult]
 ]
-SubscriptionCallback = Callable[
-    [str, str], Awaitable[None]
-]  # (client_id, uri) - keeping this as-is for now
+SubscriptionCallback = Callable[[str, str], Awaitable[None]]  # (client_id, uri)
 
 
 class ResourceManager:

--- a/src/conduit/server/protocol/tools.py
+++ b/src/conduit/server/protocol/tools.py
@@ -169,7 +169,7 @@ class ToolManager:
         self.client_handlers.pop(client_id, None)
 
     # ================================
-    # Protocol handlers (UPDATED)
+    # Protocol handlers
     # ================================
 
     async def handle_list(

--- a/src/conduit/server/request_context.py
+++ b/src/conduit/server/request_context.py
@@ -1,0 +1,103 @@
+"""Rich request context for server request handlers.
+
+Provides comprehensive client state and helper methods to request handlers,
+replacing the bare client_id parameter with an empowering context object.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from conduit.protocol.initialization import ClientCapabilities, Implementation
+from conduit.protocol.roots import Root
+
+if TYPE_CHECKING:
+    from conduit.server.client_manager import ClientManager, ClientState
+    from conduit.transport.server import ServerTransport
+
+
+@dataclass
+class RequestContext:
+    """Rich context for handling server requests.
+
+    Provides immediate access to client state, capabilities, and helper methods
+    instead of requiring handlers to work with bare client_id strings.
+
+    This context is built once at the coordinator level and threaded through
+    the request pipeline, giving handlers everything they need to make
+    informed decisions about client capabilities and state.
+    """
+
+    client_id: str
+    client_state: ClientState
+    client_manager: ClientManager
+    transport: ServerTransport
+
+    # ================================
+    # Client Information
+    # ================================
+
+    @property
+    def client_info(self) -> Implementation | None:
+        """Get client implementation info (name, version, etc.)."""
+        return self.client_state.info
+
+    @property
+    def client_capabilities(self) -> ClientCapabilities | None:
+        """Get client capabilities."""
+        return self.client_state.capabilities
+
+    @property
+    def roots(self) -> list[Root] | None:
+        """Get client's filesystem roots, if any."""
+        return self.client_state.roots
+
+    # ================================
+    # Capability Checks
+    # ================================
+
+    def can_access_filesystem(self) -> bool:
+        """True if client has provided filesystem roots."""
+        return self.roots is not None and len(self.roots) > 0
+
+    def supports_sampling(self) -> bool:
+        """True if client supports sampling requests."""
+        return (
+            self.client_capabilities is not None and self.client_capabilities.sampling
+        )
+
+    # ================================
+    # Communication Helpers
+    # ================================
+
+    async def send_to_client(self, message: dict[str, Any]) -> None:
+        """Send a message directly to this client.
+
+        Args:
+            message: JSON-RPC message to send
+
+        Raises:
+            ConnectionError: If transport fails to send
+        """
+        await self.transport.send(self.client_id, message)
+
+    # ================================
+    # Context Helpers
+    # ================================
+
+    def get_client_display_name(self) -> str:
+        """Get a human-readable name for this client."""
+        if self.client_info and self.client_info.name:
+            name = self.client_info.name
+            if self.client_info.version:
+                return f"{name} v{self.client_info.version}"
+            return name
+        return f"Client {self.client_id}"
+
+    def __str__(self) -> str:
+        """String representation for logging."""
+        return (
+            f"RequestContext(client={self.get_client_display_name()},"
+            f"id={self.client_id})"
+        )

--- a/src/conduit/server/session.py
+++ b/src/conduit/server/session.py
@@ -510,7 +510,7 @@ class ServerSession:
     ) -> None:
         """Cancels a request from a client and calls the registered callback."""
         client_id = context.client_id
-        was_cancelled = await self._coordinator.cancel_request_from_client(
+        await self._coordinator.cancel_request_from_client(
             client_id, notification.request_id
         )
         await self.callbacks.call_cancelled(client_id, notification)
@@ -532,7 +532,7 @@ class ServerSession:
         """
         client_id = context.client_id
         try:
-            result = await self._coordinator.send_request(client_id, ListRootsRequest())
+            result = await self.send_request(client_id, ListRootsRequest())
 
             if isinstance(result, ListRootsResult):
                 state = self.client_manager.get_client(client_id)

--- a/tests/server/coordinator/test_notification_handling.py
+++ b/tests/server/coordinator/test_notification_handling.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock
 
 from conduit.protocol.common import CancelledNotification
+from conduit.server.request_context import RequestContext
 
 
 class TestNotificationHandling:
@@ -11,6 +12,7 @@ class TestNotificationHandling:
         # Arrange
         await coordinator.start()
         client_id = "test_client"
+        coordinator.client_manager.register_client(client_id)
 
         # Create a mock handler
         mock_handler = AsyncMock()
@@ -38,8 +40,10 @@ class TestNotificationHandling:
         mock_handler.assert_awaited_once()
         call_args = mock_handler.call_args
 
-        # Verify handler was called with correct client_id
-        assert call_args[0][0] == client_id
+        # Verify handler was called with RequestContext (not bare client_id)
+        context = call_args[0][0]
+        assert isinstance(context, RequestContext)
+        assert context.client_id == client_id
 
         # Verify handler was called with parsed notification
         parsed_notification = call_args[0][1]

--- a/tests/server/session/test_notification_handling.py
+++ b/tests/server/session/test_notification_handling.py
@@ -4,6 +4,8 @@ from conduit.protocol.base import PROTOCOL_VERSION
 from conduit.protocol.common import CancelledNotification, ProgressNotification
 from conduit.protocol.initialization import Implementation, ServerCapabilities
 from conduit.protocol.roots import ListRootsResult, Root, RootsListChangedNotification
+from conduit.server.client_manager import ClientState
+from conduit.server.request_context import RequestContext
 from conduit.server.session import ServerConfig, ServerSession
 
 
@@ -17,31 +19,35 @@ class TestNotificationHandling:
             info=Implementation(name="test-server", version="1.0.0"),
             protocol_version=PROTOCOL_VERSION,
         )
+        self.context = RequestContext(
+            client_id="test-client",
+            client_state=ClientState(),
+            client_manager=AsyncMock(),
+            transport=self.transport,
+        )
 
     async def test_handle_cancelled_processes_cancellation_notification(self):
         # Arrange
         session = ServerSession(self.transport, self.config)
-        client_id = "test-client"
         # Need to register client to untrack request. Otherwise we'll get a ValueError
         # for trying to untrack a request with an unregistered client.
-        session.client_manager.register_client(client_id)
+        session.client_manager.register_client(self.context.client_id)
         notification = CancelledNotification(request_id="req-123")
 
         # Mock only the callback (the observable behavior)
         session.callbacks.call_cancelled = AsyncMock()
 
         # Act
-        await session._handle_cancelled(client_id, notification)
+        await session._handle_cancelled(self.context, notification)
 
         # Assert
         session.callbacks.call_cancelled.assert_awaited_once_with(
-            client_id, notification
+            self.context.client_id, notification
         )
 
     async def test_handle_progress_calls_callback(self):
         # Arrange
         session = ServerSession(self.transport, self.config)
-        client_id = "test-client"
         notification = ProgressNotification(
             progress_token="progress-123", progress=50, total=100
         )
@@ -50,11 +56,11 @@ class TestNotificationHandling:
         session.callbacks.call_progress = AsyncMock()
 
         # Act
-        await session._handle_progress(client_id, notification)
+        await session._handle_progress(self.context, notification)
 
         # Assert
         session.callbacks.call_progress.assert_awaited_once_with(
-            client_id, notification
+            self.context.client_id, notification
         )
 
     async def test_handle_roots_list_changed_updates_client_state_and_calls_callback(
@@ -62,11 +68,10 @@ class TestNotificationHandling:
     ):
         # Arrange
         session = ServerSession(self.transport, self.config)
-        client_id = "test-client"
         notification = RootsListChangedNotification()
 
         # Register client to create state
-        session.client_manager.register_client(client_id)
+        session.client_manager.register_client(self.context.client_id)
 
         # Mock successful coordinator response
         new_roots = [
@@ -74,42 +79,39 @@ class TestNotificationHandling:
             Root(uri="file:///home/user/docs", name="Documents"),
         ]
         list_roots_result = ListRootsResult(roots=new_roots)
-        session._coordinator.send_request = AsyncMock(return_value=list_roots_result)
+        session.send_request = AsyncMock(return_value=list_roots_result)
 
         # Mock callback
         session.callbacks.call_roots_changed = AsyncMock()
 
         # Act
-        await session._handle_roots_list_changed(client_id, notification)
+        await session._handle_roots_list_changed(self.context, notification)
 
         # Assert - verify client state was updated
-        state = session.client_manager.get_client(client_id)
+        state = session.client_manager.get_client(self.context.client_id)
         assert state.roots == new_roots
 
         # Assert - verify callback was called with client state
         session.callbacks.call_roots_changed.assert_awaited_once_with(
-            client_id, new_roots
+            self.context.client_id, new_roots
         )
 
     async def test_transport_error_does_not_propagate_when_roots_list_changed(self):
         # Arrange
         session = ServerSession(self.transport, self.config)
-        client_id = "test-client"
         notification = RootsListChangedNotification()
 
         # Register client to create state
-        session.client_manager.register_client(client_id)
+        session.client_manager.register_client(self.context.client_id)
 
         # Mock coordinator to raise exception
-        session._coordinator.send_request = AsyncMock(
-            side_effect=Exception("Transport error")
-        )
+        session.send_request = AsyncMock(side_effect=Exception("Transport error"))
 
         # Mock callback (should not be called)
         session.callbacks.call_roots_changed = AsyncMock()
 
         # Act - should not raise exception
-        await session._handle_roots_list_changed(client_id, notification)
+        await session._handle_roots_list_changed(self.context, notification)
 
         # Assert - callback should not be called on error
         session.callbacks.call_roots_changed.assert_not_awaited()
@@ -119,16 +121,15 @@ class TestNotificationHandling:
     ):
         # Arrange
         session = ServerSession(self.transport, self.config)
-        client_id = "test-client"
         notification = RootsListChangedNotification()
 
         # Register client to create state
-        session.client_manager.register_client(client_id)
+        session.client_manager.register_client(self.context.client_id)
 
         # Mock successful coordinator response
         new_roots = [Root(uri="file:///home/user/project", name="Project")]
         list_roots_result = ListRootsResult(roots=new_roots)
-        session._coordinator.send_request = AsyncMock(return_value=list_roots_result)
+        session.send_request = AsyncMock(return_value=list_roots_result)
 
         # Mock callback to raise exception
         session.callbacks.call_roots_changed = AsyncMock(
@@ -136,13 +137,13 @@ class TestNotificationHandling:
         )
 
         # Act - should not raise exception despite callback failure
-        await session._handle_roots_list_changed(client_id, notification)
+        await session._handle_roots_list_changed(self.context, notification)
 
         # Assert - client state should still be updated despite callback failure
-        state = session.client_manager.get_client(client_id)
+        state = session.client_manager.get_client(self.context.client_id)
         assert state.roots == new_roots
 
         # Assert - callback was attempted
         session.callbacks.call_roots_changed.assert_awaited_once_with(
-            client_id, new_roots
+            self.context.client_id, new_roots
         )

--- a/tests/server/session/test_send_message.py
+++ b/tests/server/session/test_send_message.py
@@ -72,12 +72,13 @@ class TestSendMessage:
         session._coordinator.send_request = AsyncMock(return_value=expected_result)
 
         # Act
-        result = await session.send_request(client_id, request)
+        timeout = 30.0
+        result = await session.send_request(client_id, request, timeout)
 
         # Assert
         assert result == expected_result
         session._coordinator.send_request.assert_awaited_once_with(
-            client_id, request, 30.0
+            client_id, request, timeout
         )
 
     async def test_send_request_to_client_propagates_coordinator_error(self):


### PR DESCRIPTION
## What changed?

Introduced `RequestContext` to replace bare `client_id` strings throughout the server request handling pipeline. Updated all protocol handlers (tools, resources, prompts, completions, logging) and session handlers to accept rich context objects instead of client identifiers.

- Added `RequestContext` dataclass with client state, capabilities, and helper methods
- Updated `MessageCoordinator` to build context once per request and thread it through handlers
- Modified all `*Manager` classes to use `RequestContext` in their protocol handlers
- Updated handler type aliases: `RequestHandler` and `NotificationHandler` now expect context
- Preserved existing callback interfaces for user-registered handlers
- Updated all tests to work with the new context-aware signatures

Addresses server half of #39 

## Why?

The previous architecture required handlers to work with bare `client_id` strings, forcing them to manually reconstruct client context when needed. This created a poor developer experience with limited access to client capabilities, state information, and communication channels.

The new `RequestContext` provides immediate access to:
- Client capabilities and protocol information
- Helper methods like `can_access_filesystem()` and `supports_sampling()`
- Direct client communication via `send_to_client()`
- Rich client display names for better logging

## Impact

- **Breaking Change**: All custom request and notification handlers must update their signatures
- **Empowering**: Handlers now have rich context without manual reconstruction
- **Type Safe**: Full type safety through the request pipeline
- **Better DX**: IDE autocomplete and discoverability of available client context
- **Foundation**: Sets up architecture for context-aware handler development

## Testing

- All existing tests updated to use `RequestContext`
- Test coverage maintained across all protocol managers
- Pyright type checking passes throughout the codebase
- Both unit and integration tests verify context flow end-to-end

## Review notes

This is a comprehensive architectural change that touches most of the server-side codebase. The pattern is consistent throughout: handlers receive `RequestContext` instead of `client_id` strings, while user-facing callback interfaces remain unchanged for API stability.

Client-side similar refactoring will follow in a separate PR.

## Checklist

- [x] All new and old tests pass
- [x] Code follows our style guidelines  
- [x] Documentation updated if needed
- [x] Breaking changes documented in commit messages