### PR TITLE
Chore/rename request context

### DIFF
--- a/src/conduit/client/coordinator.py
+++ b/src/conduit/client/coordinator.py
@@ -10,7 +10,7 @@ import uuid
 from collections.abc import Coroutine
 from typing import Any, Awaitable, Callable, TypeVar
 
-from conduit.client.request_context import RequestContext
+from conduit.client.message_context import MessageContext
 from conduit.client.server_manager import ServerManager
 from conduit.protocol.base import (
     INTERNAL_ERROR,
@@ -35,9 +35,9 @@ TRequest = TypeVar("TRequest", bound=Request)
 TResult = TypeVar("TResult", bound=Result)
 TNotification = TypeVar("TNotification", bound=Notification)
 
-RequestHandler = Callable[[RequestContext, TRequest], Awaitable[TResult | Error]]
+RequestHandler = Callable[[MessageContext, TRequest], Awaitable[TResult | Error]]
 NotificationHandler = Callable[
-    [RequestContext, TNotification], Coroutine[Any, Any, None]
+    [MessageContext, TNotification], Coroutine[Any, Any, None]
 ]
 
 
@@ -137,14 +137,14 @@ class MessageCoordinator:
     # Build context
     # ================================
 
-    def _build_context(self, server_id: str) -> RequestContext:
+    def _build_context(self, server_id: str) -> MessageContext:
         """Builds context for a request.
 
         Args:
             server_id: ID of the server making the request
 
         Returns:
-            RequestContext: Context with server state and helpers
+            MessageContext: Context with server state and helpers
 
         Raises:
             ValueError: If the server is not registered with the client
@@ -153,7 +153,7 @@ class MessageCoordinator:
         if server_state is None:
             raise ValueError(f"Server {server_id} not registered")
 
-        return RequestContext(
+        return MessageContext(
             server_id=server_id,
             server_state=server_state,
             server_manager=self.server_manager,
@@ -250,7 +250,7 @@ class MessageCoordinator:
     async def _execute_request_handler(
         self,
         handler: RequestHandler,
-        context: RequestContext,
+        context: MessageContext,
         request_id: str | int,
         request: Request,
     ) -> None:

--- a/src/conduit/client/message_context.py
+++ b/src/conduit/client/message_context.py
@@ -11,8 +11,8 @@ if TYPE_CHECKING:
 
 
 @dataclass
-class RequestContext:
-    """Rich context for handling server -> client requests.
+class MessageContext:
+    """Rich context for handling server -> client messages.
 
     Provides immediate access to server state, capabilities, and helper methods.
     """

--- a/src/conduit/client/message_context.py
+++ b/src/conduit/client/message_context.py
@@ -60,6 +60,6 @@ class MessageContext:
     def __str__(self) -> str:
         """String representation for logging."""
         return (
-            f"RequestContext(server={self.get_server_display_name()},"
+            f"MessageContext(server={self.get_server_display_name()},"
             f"id={self.server_id})"
         )

--- a/src/conduit/client/protocol/elicitation.py
+++ b/src/conduit/client/protocol/elicitation.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Awaitable, Callable
 
-from conduit.client.request_context import RequestContext
+from conduit.client.message_context import MessageContext
 from conduit.protocol.elicitation import ElicitRequest, ElicitResult
 
 
@@ -19,7 +19,7 @@ class ElicitationManager:
         self.logger = logging.getLogger("conduit.client.protocol.elicitation")
 
     async def handle_elicitation(
-        self, context: RequestContext, request: ElicitRequest
+        self, context: MessageContext, request: ElicitRequest
     ) -> ElicitResult:
         """Elicit a response from the user.
 

--- a/src/conduit/client/protocol/roots.py
+++ b/src/conduit/client/protocol/roots.py
@@ -1,7 +1,7 @@
 import logging
 from copy import deepcopy
 
-from conduit.client.request_context import RequestContext
+from conduit.client.message_context import MessageContext
 from conduit.protocol.roots import ListRootsRequest, ListRootsResult, Root
 
 
@@ -78,7 +78,7 @@ class RootsManager:
     # ================================
 
     async def handle_list_roots(
-        self, context: RequestContext, request: ListRootsRequest
+        self, context: MessageContext, request: ListRootsRequest
     ) -> ListRootsResult:
         """List the roots available to the server making the request."""
         roots = self.get_server_roots(context.server_id)

--- a/src/conduit/client/protocol/sampling.py
+++ b/src/conduit/client/protocol/sampling.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Awaitable, Callable
 
-from conduit.client.request_context import RequestContext
+from conduit.client.message_context import MessageContext
 from conduit.protocol.sampling import CreateMessageRequest, CreateMessageResult
 
 
@@ -19,7 +19,7 @@ class SamplingManager:
         self.logger = logging.getLogger("conduit.client.protocol.sampling")
 
     async def handle_create_message(
-        self, context: RequestContext, request: CreateMessageRequest
+        self, context: MessageContext, request: CreateMessageRequest
     ) -> CreateMessageResult:
         """Sample the host LLM for the server.
 

--- a/src/conduit/client/session.py
+++ b/src/conduit/client/session.py
@@ -14,13 +14,13 @@ from typing import Any, cast
 
 from conduit.client.callbacks import CallbackManager
 from conduit.client.coordinator import MessageCoordinator
+from conduit.client.message_context import MessageContext
 from conduit.client.protocol.elicitation import (
     ElicitationManager,
     ElicitationNotConfiguredError,
 )
 from conduit.client.protocol.roots import RootsManager
 from conduit.client.protocol.sampling import SamplingManager, SamplingNotConfiguredError
-from conduit.client.request_context import RequestContext
 from conduit.client.server_manager import ServerManager
 from conduit.protocol.base import (
     INTERNAL_ERROR,
@@ -293,7 +293,7 @@ class ClientSession:
     # ================================
 
     async def _handle_ping(
-        self, context: RequestContext, request: PingRequest
+        self, context: MessageContext, request: PingRequest
     ) -> EmptyResult:
         """Returns an empty result."""
 
@@ -304,7 +304,7 @@ class ClientSession:
     # ================================
 
     async def _handle_list_roots(
-        self, context: RequestContext, request: ListRootsRequest
+        self, context: MessageContext, request: ListRootsRequest
     ) -> ListRootsResult | Error:
         """Returns the roots available to the server.
 
@@ -324,7 +324,7 @@ class ClientSession:
     # ================================
 
     async def _handle_sampling(
-        self, context: RequestContext, request: CreateMessageRequest
+        self, context: MessageContext, request: CreateMessageRequest
     ) -> CreateMessageResult | Error:
         """Creates a message using the configured sampling handler.
 
@@ -354,7 +354,7 @@ class ClientSession:
     # ================================
 
     async def _handle_elicitation(
-        self, context: RequestContext, request: ElicitRequest
+        self, context: MessageContext, request: ElicitRequest
     ) -> ElicitResult | Error:
         """Returns an elicitation result using the configured elicitation handler.
 
@@ -384,7 +384,7 @@ class ClientSession:
     # ================================
 
     async def _handle_cancelled(
-        self, context: RequestContext, notification: CancelledNotification
+        self, context: MessageContext, notification: CancelledNotification
     ) -> None:
         """Cancels a request from the server and calls the registered callback."""
         request_exists = (
@@ -400,13 +400,13 @@ class ClientSession:
             await self.callbacks.call_cancelled(context.server_id, notification)
 
     async def _handle_progress(
-        self, context: RequestContext, notification: ProgressNotification
+        self, context: MessageContext, notification: ProgressNotification
     ) -> None:
         """Calls the registered callback for progress updates."""
         await self.callbacks.call_progress(context.server_id, notification)
 
     async def _handle_prompts_list_changed(
-        self, context: RequestContext, notification: PromptListChangedNotification
+        self, context: MessageContext, notification: PromptListChangedNotification
     ) -> None:
         """Fetches the updated prompts list and calls the registered callback.
 
@@ -433,7 +433,7 @@ class ClientSession:
             )
 
     async def _handle_resources_list_changed(
-        self, context: RequestContext, notification: ResourceListChangedNotification
+        self, context: MessageContext, notification: ResourceListChangedNotification
     ) -> None:
         """Fetches the updated resources/templates and calls the registered callback.
 
@@ -479,7 +479,7 @@ class ClientSession:
             )
 
     async def _handle_resources_updated(
-        self, context: RequestContext, notification: ResourceUpdatedNotification
+        self, context: MessageContext, notification: ResourceUpdatedNotification
     ) -> None:
         """Reads the updated resource content and calls the registered callback.
 
@@ -502,7 +502,7 @@ class ClientSession:
             )
 
     async def _handle_tools_list_changed(
-        self, context: RequestContext, notification: ToolListChangedNotification
+        self, context: MessageContext, notification: ToolListChangedNotification
     ) -> None:
         """Fetches the updated tools list and calls the registered callback.
 
@@ -529,7 +529,7 @@ class ClientSession:
             )
 
     async def _handle_logging_message(
-        self, context: RequestContext, notification: LoggingMessageNotification
+        self, context: MessageContext, notification: LoggingMessageNotification
     ) -> None:
         """Calls the registered callback for logging messages."""
         await self.callbacks.call_logging_message(context.server_id, notification)

--- a/src/conduit/server/message_context.py
+++ b/src/conduit/server/message_context.py
@@ -104,6 +104,6 @@ class MessageContext:
     def __str__(self) -> str:
         """String representation for logging."""
         return (
-            f"RequestContext(client={self.get_client_display_name()},"
+            f"MessageContext(client={self.get_client_display_name()},"
             f"id={self.client_id})"
         )

--- a/src/conduit/server/message_context.py
+++ b/src/conduit/server/message_context.py
@@ -18,14 +18,14 @@ if TYPE_CHECKING:
 
 
 @dataclass
-class RequestContext:
-    """Rich context for handling client -> server requests.
+class MessageContext:
+    """Rich context for handling client -> server messages.
 
     Provides immediate access to client state, capabilities, and helper methods
     instead of requiring handlers to work with bare client_id strings.
 
     This context is built once at the coordinator level and threaded through
-    the request pipeline, giving handlers everything they need to make
+    the message pipeline, giving handlers everything they need to make
     informed decisions about client capabilities and state.
     """
 

--- a/src/conduit/server/protocol/completions.py
+++ b/src/conduit/server/protocol/completions.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Awaitable, Callable
 from conduit.protocol.completions import CompleteRequest, CompleteResult
 
 if TYPE_CHECKING:
-    from conduit.server.request_context import RequestContext
+    from conduit.server.message_context import MessageContext
 
 
 class CompletionNotConfiguredError(Exception):
@@ -14,13 +14,13 @@ class CompletionNotConfiguredError(Exception):
 class CompletionManager:
     def __init__(self):
         self.completion_handler: (
-            Callable[["RequestContext", CompleteRequest], Awaitable[CompleteResult]]
+            Callable[["MessageContext", CompleteRequest], Awaitable[CompleteResult]]
             | None
         ) = None
         self.logger = logging.getLogger("conduit.server.protocol.completions")
 
     async def handle_complete(
-        self, context: "RequestContext", request: CompleteRequest
+        self, context: "MessageContext", request: CompleteRequest
     ) -> CompleteResult:
         """Generate a completion for a given argument.
 

--- a/src/conduit/server/protocol/logging.py
+++ b/src/conduit/server/protocol/logging.py
@@ -5,7 +5,7 @@ from conduit.protocol.common import EmptyResult
 from conduit.protocol.logging import LoggingLevel, SetLevelRequest
 
 if TYPE_CHECKING:
-    from conduit.server.request_context import RequestContext
+    from conduit.server.message_context import MessageContext
 
 
 class LoggingManager:
@@ -55,7 +55,7 @@ class LoggingManager:
         self._client_log_levels.pop(client_id, None)
 
     async def handle_set_level(
-        self, context: "RequestContext", request: SetLevelRequest
+        self, context: "MessageContext", request: SetLevelRequest
     ) -> EmptyResult:
         """Set the MCP protocol logging level for a specific client.
 

--- a/src/conduit/server/protocol/prompts.py
+++ b/src/conduit/server/protocol/prompts.py
@@ -11,10 +11,10 @@ from conduit.protocol.prompts import (
 )
 
 if TYPE_CHECKING:
-    from conduit.server.request_context import RequestContext
+    from conduit.server.message_context import MessageContext
 
 PromptHandler = Callable[
-    ["RequestContext", GetPromptRequest], Awaitable[GetPromptResult]
+    ["MessageContext", GetPromptRequest], Awaitable[GetPromptResult]
 ]
 
 
@@ -170,7 +170,7 @@ class PromptManager:
     # ================================
 
     async def handle_list_prompts(
-        self, context: "RequestContext", request: ListPromptsRequest
+        self, context: "MessageContext", request: ListPromptsRequest
     ) -> ListPromptsResult:
         """List all prompts available to this client.
 
@@ -188,7 +188,7 @@ class PromptManager:
         return ListPromptsResult(prompts=list(prompts.values()))
 
     async def handle_get_prompt(
-        self, context: "RequestContext", request: GetPromptRequest
+        self, context: "MessageContext", request: GetPromptRequest
     ) -> GetPromptResult:
         """Execute a prompt request for a specific client.
 

--- a/src/conduit/server/protocol/resources.py
+++ b/src/conduit/server/protocol/resources.py
@@ -20,11 +20,11 @@ from conduit.protocol.resources import (
 )
 
 if TYPE_CHECKING:
-    from conduit.server.request_context import RequestContext
+    from conduit.server.message_context import MessageContext
 
 
 ResourceHandler = Callable[
-    ["RequestContext", ReadResourceRequest], Awaitable[ReadResourceResult]
+    ["MessageContext", ReadResourceRequest], Awaitable[ReadResourceResult]
 ]
 SubscriptionCallback = Callable[[str, str], Awaitable[None]]  # (client_id, uri)
 
@@ -242,21 +242,21 @@ class ResourceManager:
     # ===============================
 
     async def handle_list_resources(
-        self, context: "RequestContext", request: ListResourcesRequest
+        self, context: "MessageContext", request: ListResourcesRequest
     ) -> ListResourcesResult:
         """List all resources available to a specific client."""
         resources = self.get_client_resources(context.client_id)
         return ListResourcesResult(resources=list(resources.values()))
 
     async def handle_list_templates(
-        self, context: "RequestContext", request: ListResourceTemplatesRequest
+        self, context: "MessageContext", request: ListResourceTemplatesRequest
     ) -> ListResourceTemplatesResult:
         """List all resource templates available to a specific client."""
         templates = self.get_client_templates(context.client_id)
         return ListResourceTemplatesResult(resource_templates=list(templates.values()))
 
     async def handle_read(
-        self, context: "RequestContext", request: ReadResourceRequest
+        self, context: "MessageContext", request: ReadResourceRequest
     ) -> ReadResourceResult:
         """Read a resource by URI for a specific client.
 
@@ -298,7 +298,7 @@ class ResourceManager:
         raise KeyError(f"No resource or template handler found for URI: {uri}")
 
     async def handle_subscribe(
-        self, context: "RequestContext", request: SubscribeRequest
+        self, context: "MessageContext", request: SubscribeRequest
     ) -> EmptyResult:
         """Subscribe a client to resource updates for the given URI.
 
@@ -343,7 +343,7 @@ class ResourceManager:
         return EmptyResult()
 
     async def handle_unsubscribe(
-        self, context: "RequestContext", request: UnsubscribeRequest
+        self, context: "MessageContext", request: UnsubscribeRequest
     ) -> EmptyResult:
         """Unsubscribe a client from resource updates for the given URI.
 

--- a/src/conduit/server/protocol/tools.py
+++ b/src/conduit/server/protocol/tools.py
@@ -14,9 +14,9 @@ from conduit.protocol.tools import (
 )
 
 if TYPE_CHECKING:
-    from conduit.server.request_context import RequestContext
+    from conduit.server.message_context import MessageContext
 
-ToolHandler = Callable[["RequestContext", CallToolRequest], Awaitable[CallToolResult]]
+ToolHandler = Callable[["MessageContext", CallToolRequest], Awaitable[CallToolResult]]
 
 
 class ToolManager:
@@ -173,7 +173,7 @@ class ToolManager:
     # ================================
 
     async def handle_list(
-        self, context: "RequestContext", request: ListToolsRequest
+        self, context: "MessageContext", request: ListToolsRequest
     ) -> ListToolsResult:
         """Lists tools for a specific client.
 
@@ -191,7 +191,7 @@ class ToolManager:
         return ListToolsResult(tools=list(tools.values()))
 
     async def handle_call(
-        self, context: "RequestContext", request: CallToolRequest
+        self, context: "MessageContext", request: CallToolRequest
     ) -> CallToolResult:
         """Execute a tool call request for a specific client.
 

--- a/src/conduit/server/session.py
+++ b/src/conduit/server/session.py
@@ -64,6 +64,7 @@ from conduit.protocol.tools import (
 from conduit.server.callbacks import CallbackManager
 from conduit.server.client_manager import ClientManager
 from conduit.server.coordinator import MessageCoordinator
+from conduit.server.message_context import MessageContext
 from conduit.server.protocol.completions import (
     CompletionManager,
     CompletionNotConfiguredError,
@@ -72,7 +73,6 @@ from conduit.server.protocol.logging import LoggingManager
 from conduit.server.protocol.prompts import PromptManager
 from conduit.server.protocol.resources import ResourceManager
 from conduit.server.protocol.tools import ToolManager
-from conduit.server.request_context import RequestContext
 from conduit.transport.server import ServerTransport
 
 
@@ -179,7 +179,7 @@ class ServerSession:
     # ================================
 
     async def _handle_initialize(
-        self, context: RequestContext, request: InitializeRequest
+        self, context: MessageContext, request: InitializeRequest
     ) -> InitializeResult | Error:
         """Handle the first step of the MCP initialization handshake.
 
@@ -227,7 +227,7 @@ class ServerSession:
         )
 
     async def _handle_initialized(
-        self, context: RequestContext, notification: InitializedNotification
+        self, context: MessageContext, notification: InitializedNotification
     ) -> None:
         """Complete the initialization handshake.
 
@@ -246,7 +246,7 @@ class ServerSession:
     # ================================
 
     async def _handle_ping(
-        self, context: RequestContext, request: PingRequest
+        self, context: MessageContext, request: PingRequest
     ) -> EmptyResult:
         """Always returns an empty result.
 
@@ -259,7 +259,7 @@ class ServerSession:
     # ================================
 
     async def _handle_list_tools(
-        self, context: RequestContext, request: ListToolsRequest
+        self, context: MessageContext, request: ListToolsRequest
     ) -> ListToolsResult | Error:
         """Returns the list of available tools.
 
@@ -276,7 +276,7 @@ class ServerSession:
         return await self.tools.handle_list(context, request)
 
     async def _handle_call_tool(
-        self, context: RequestContext, request: CallToolRequest
+        self, context: MessageContext, request: CallToolRequest
     ) -> CallToolResult | Error:
         """Executes a tool call.
 
@@ -302,7 +302,7 @@ class ServerSession:
     # ================================
 
     async def _handle_list_prompts(
-        self, context: RequestContext, request: ListPromptsRequest
+        self, context: MessageContext, request: ListPromptsRequest
     ) -> ListPromptsResult | Error:
         """Returns the list of available prompts.
 
@@ -318,7 +318,7 @@ class ServerSession:
         return await self.prompts.handle_list_prompts(context, request)
 
     async def _handle_get_prompt(
-        self, context: RequestContext, request: GetPromptRequest
+        self, context: MessageContext, request: GetPromptRequest
     ) -> GetPromptResult | Error:
         """Returns the contents of a specific prompt.
 
@@ -347,7 +347,7 @@ class ServerSession:
     # ================================
 
     async def _handle_list_resources(
-        self, context: RequestContext, request: ListResourcesRequest
+        self, context: MessageContext, request: ListResourcesRequest
     ) -> ListResourcesResult | Error:
         """Returns the list of available resources.
 
@@ -364,7 +364,7 @@ class ServerSession:
         return await self.resources.handle_list_resources(context, request)
 
     async def _handle_list_resource_templates(
-        self, context: RequestContext, request: ListResourceTemplatesRequest
+        self, context: MessageContext, request: ListResourceTemplatesRequest
     ) -> ListResourceTemplatesResult | Error:
         """Returns the list of available resource templates.
 
@@ -380,7 +380,7 @@ class ServerSession:
         return await self.resources.handle_list_templates(context, request)
 
     async def _handle_read_resource(
-        self, context: RequestContext, request: ReadResourceRequest
+        self, context: MessageContext, request: ReadResourceRequest
     ) -> ReadResourceResult | Error:
         """Returns the contents of a specific resource.
 
@@ -405,7 +405,7 @@ class ServerSession:
             )
 
     async def _handle_subscribe(
-        self, context: RequestContext, request: SubscribeRequest
+        self, context: MessageContext, request: SubscribeRequest
     ) -> EmptyResult | Error:
         """Subscribes a client to a resource.
 
@@ -428,7 +428,7 @@ class ServerSession:
             return Error(code=METHOD_NOT_FOUND, message=str(e))
 
     async def _handle_unsubscribe(
-        self, context: RequestContext, request: UnsubscribeRequest
+        self, context: MessageContext, request: UnsubscribeRequest
     ) -> EmptyResult | Error:
         """Unsubscribes a client from a resource.
 
@@ -455,7 +455,7 @@ class ServerSession:
     # ================================
 
     async def _handle_complete(
-        self, context: RequestContext, request: CompleteRequest
+        self, context: MessageContext, request: CompleteRequest
     ) -> CompleteResult | Error:
         """Generates a completion for a given prompt.
 
@@ -487,7 +487,7 @@ class ServerSession:
     # ================================
 
     async def _handle_set_level(
-        self, context: RequestContext, request: SetLevelRequest
+        self, context: MessageContext, request: SetLevelRequest
     ) -> EmptyResult | Error:
         """Sets the logging level for the given client.
 
@@ -508,7 +508,7 @@ class ServerSession:
     # ================================
 
     async def _handle_cancelled(
-        self, context: RequestContext, notification: CancelledNotification
+        self, context: MessageContext, notification: CancelledNotification
     ) -> None:
         """Cancels a request from a client and calls the registered callback."""
         client_id = context.client_id
@@ -518,14 +518,14 @@ class ServerSession:
         await self.callbacks.call_cancelled(client_id, notification)
 
     async def _handle_progress(
-        self, context: RequestContext, notification: ProgressNotification
+        self, context: MessageContext, notification: ProgressNotification
     ) -> None:
         """Calls the registered callback for progress updates."""
         client_id = context.client_id
         await self.callbacks.call_progress(client_id, notification)
 
     async def _handle_roots_list_changed(
-        self, context: RequestContext, notification: RootsListChangedNotification
+        self, context: MessageContext, notification: RootsListChangedNotification
     ) -> None:
         """Handles roots/list_changed notification.
 

--- a/tests/client/coordinator/test_notification_handling.py
+++ b/tests/client/coordinator/test_notification_handling.py
@@ -1,6 +1,6 @@
 from unittest.mock import AsyncMock
 
-from conduit.client.request_context import RequestContext
+from conduit.client.message_context import MessageContext
 from conduit.protocol.common import CancelledNotification
 
 
@@ -40,7 +40,7 @@ class TestNotificationHandling:
 
         # Verify handler was called with request context and parsed notification
         context = call_args[0][0]
-        assert isinstance(context, RequestContext)
+        assert isinstance(context, MessageContext)
         assert context.server_id == server_id
 
         parsed_notification = call_args[0][1]

--- a/tests/client/coordinator/test_request_handling.py
+++ b/tests/client/coordinator/test_request_handling.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from conduit.client.request_context import RequestContext
+from conduit.client.message_context import MessageContext
 from conduit.protocol.base import INTERNAL_ERROR, METHOD_NOT_FOUND
 from conduit.protocol.common import EmptyResult, PingRequest
 from conduit.protocol.elicitation import ElicitRequest, ElicitResult
@@ -14,7 +14,7 @@ class TestRequestHandling:
         handled_requests = []
 
         async def mock_handler(
-            context: RequestContext, request: PingRequest
+            context: MessageContext, request: PingRequest
         ) -> EmptyResult:
             handled_requests.append((context, request))
             return EmptyResult()
@@ -46,7 +46,7 @@ class TestRequestHandling:
         # Assert: Handler was called correctly
         assert len(handled_requests) == 1
         context, request = handled_requests[0]
-        assert isinstance(context, RequestContext)
+        assert isinstance(context, MessageContext)
         assert context.server_id == "test-server"
         assert request.method == "ping"
 
@@ -75,7 +75,7 @@ class TestRequestHandling:
         handler_called = False
 
         async def should_not_be_called(
-            context: RequestContext,
+            context: MessageContext,
             request: ElicitRequest,
         ) -> ElicitResult:
             nonlocal handler_called
@@ -136,7 +136,7 @@ class TestRequestHandling:
     ):
         # Arrange: Set up a handler that throws an exception
         async def failing_handler(
-            context: RequestContext, request: PingRequest
+            context: MessageContext, request: PingRequest
         ) -> EmptyResult:
             raise ValueError("Something went wrong in the handler")
 
@@ -180,7 +180,7 @@ class TestRequestHandling:
         handler_cancelled = False
 
         async def slow_handler(
-            context: RequestContext, request: PingRequest
+            context: MessageContext, request: PingRequest
         ) -> EmptyResult:
             nonlocal handler_cancelled
             handler_started.set()  # Signal that handler has started

--- a/tests/client/protocol/test_elicitation_manager.py
+++ b/tests/client/protocol/test_elicitation_manager.py
@@ -2,11 +2,11 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from conduit.client.message_context import MessageContext
 from conduit.client.protocol.elicitation import (
     ElicitationManager,
     ElicitationNotConfiguredError,
 )
-from conduit.client.request_context import RequestContext
 from conduit.protocol.elicitation import (
     ElicitRequest,
     ElicitResult,
@@ -17,7 +17,7 @@ from conduit.protocol.elicitation import (
 
 class TestElicitationManager:
     def setup_method(self):
-        self.context = RequestContext(
+        self.context = MessageContext(
             server_id="server_id",
             server_state=AsyncMock(),
             server_manager=AsyncMock(),

--- a/tests/client/protocol/test_roots_manager.py
+++ b/tests/client/protocol/test_roots_manager.py
@@ -1,13 +1,13 @@
 from unittest.mock import AsyncMock
 
+from conduit.client.message_context import MessageContext
 from conduit.client.protocol.roots import RootsManager
-from conduit.client.request_context import RequestContext
 from conduit.protocol.roots import ListRootsRequest, ListRootsResult, Root
 
 
 class TestRootsManager:
     def setup_method(self):
-        self.context = RequestContext(
+        self.context = MessageContext(
             server_id="server_id",
             server_state=AsyncMock(),
             server_manager=AsyncMock(),

--- a/tests/client/protocol/test_sampling_manager.py
+++ b/tests/client/protocol/test_sampling_manager.py
@@ -2,15 +2,15 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from conduit.client.message_context import MessageContext
 from conduit.client.protocol.sampling import SamplingManager, SamplingNotConfiguredError
-from conduit.client.request_context import RequestContext
 from conduit.protocol.content import TextContent
 from conduit.protocol.sampling import CreateMessageRequest, CreateMessageResult
 
 
 class TestSamplingManager:
     def setup_method(self):
-        self.context = RequestContext(
+        self.context = MessageContext(
             server_id="server_id",
             server_state=AsyncMock(),
             server_manager=AsyncMock(),

--- a/tests/client/session/test_elicitation_handling.py
+++ b/tests/client/session/test_elicitation_handling.py
@@ -1,7 +1,7 @@
 from unittest.mock import AsyncMock
 
+from conduit.client.message_context import MessageContext
 from conduit.client.protocol.elicitation import ElicitationNotConfiguredError
-from conduit.client.request_context import RequestContext
 from conduit.client.session import ClientConfig, ClientSession
 from conduit.protocol.base import INTERNAL_ERROR, METHOD_NOT_FOUND, Error
 from conduit.protocol.elicitation import ElicitRequest, ElicitResult
@@ -21,7 +21,7 @@ class TestElicitationRequestHandling:
             client_info=Implementation(name="test-client", version="1.0.0"),
             capabilities=ClientCapabilities(elicitation=False),
         )
-        self.context = RequestContext(
+        self.context = MessageContext(
             server_id="server_id",
             server_state=AsyncMock(),
             server_manager=AsyncMock(),

--- a/tests/client/session/test_notification_handling.py
+++ b/tests/client/session/test_notification_handling.py
@@ -1,6 +1,6 @@
 from unittest.mock import AsyncMock, Mock
 
-from conduit.client.request_context import RequestContext
+from conduit.client.message_context import MessageContext
 from conduit.client.session import ClientConfig, ClientSession
 from conduit.protocol.base import METHOD_NOT_FOUND, Error, Request
 from conduit.protocol.common import (
@@ -46,7 +46,7 @@ class TestNotificationHandling:
         )
         self.session = ClientSession(self.transport, self.config)
         self.session.server_manager.register_server("server_id")
-        self.context = RequestContext(
+        self.context = MessageContext(
             server_id="server_id",
             server_state=AsyncMock(),
             server_manager=AsyncMock(),

--- a/tests/client/session/test_roots_handling.py
+++ b/tests/client/session/test_roots_handling.py
@@ -1,6 +1,6 @@
 from unittest.mock import AsyncMock
 
-from conduit.client.request_context import RequestContext
+from conduit.client.message_context import MessageContext
 from conduit.client.session import ClientConfig, ClientSession
 from conduit.protocol.base import METHOD_NOT_FOUND, Error
 from conduit.protocol.initialization import (
@@ -24,7 +24,7 @@ class TestRootsRequestHandling:
             client_info=Implementation(name="test-client", version="1.0.0"),
             capabilities=ClientCapabilities(roots=None),
         )
-        self.context = RequestContext(
+        self.context = MessageContext(
             server_id="server_id",
             server_state=AsyncMock(),
             server_manager=AsyncMock(),

--- a/tests/client/session/test_sampling_handling.py
+++ b/tests/client/session/test_sampling_handling.py
@@ -1,7 +1,7 @@
 from unittest.mock import AsyncMock
 
+from conduit.client.message_context import MessageContext
 from conduit.client.protocol.sampling import SamplingNotConfiguredError
-from conduit.client.request_context import RequestContext
 from conduit.client.session import ClientConfig, ClientSession
 from conduit.protocol.base import INTERNAL_ERROR, METHOD_NOT_FOUND, Error
 from conduit.protocol.content import TextContent
@@ -22,7 +22,7 @@ class TestSamplingRequestHandling:
             client_info=Implementation(name="test-client", version="1.0.0"),
             capabilities=ClientCapabilities(sampling=False),
         )
-        self.context = RequestContext(
+        self.context = MessageContext(
             server_id="server_id",
             server_state=AsyncMock(),
             server_manager=AsyncMock(),

--- a/tests/server/coordinator/test_notification_handling.py
+++ b/tests/server/coordinator/test_notification_handling.py
@@ -1,7 +1,7 @@
 from unittest.mock import AsyncMock
 
 from conduit.protocol.common import CancelledNotification
-from conduit.server.request_context import RequestContext
+from conduit.server.message_context import MessageContext
 
 
 class TestNotificationHandling:
@@ -40,9 +40,9 @@ class TestNotificationHandling:
         mock_handler.assert_awaited_once()
         call_args = mock_handler.call_args
 
-        # Verify handler was called with RequestContext (not bare client_id)
+        # Verify handler was called with MessageContext
         context = call_args[0][0]
-        assert isinstance(context, RequestContext)
+        assert isinstance(context, MessageContext)
         assert context.client_id == client_id
 
         # Verify handler was called with parsed notification

--- a/tests/server/coordinator/test_request_handling.py
+++ b/tests/server/coordinator/test_request_handling.py
@@ -4,7 +4,7 @@ from conduit.protocol.base import INTERNAL_ERROR, METHOD_NOT_FOUND
 from conduit.protocol.common import EmptyResult
 from conduit.protocol.jsonrpc import Request
 from conduit.protocol.resources import ReadResourceRequest, ReadResourceResult
-from conduit.server.request_context import RequestContext
+from conduit.server.message_context import MessageContext
 
 
 class TestRequestHandling:
@@ -16,7 +16,7 @@ class TestRequestHandling:
         handled_requests = []
 
         async def mock_handler(
-            context: RequestContext, request: Request
+            context: MessageContext, request: Request
         ) -> EmptyResult:
             handled_requests.append((context, request))
             return EmptyResult()
@@ -41,7 +41,7 @@ class TestRequestHandling:
         # Assert: Handler was called correctly
         assert len(handled_requests) == 1
         context, request = handled_requests[0]
-        assert isinstance(context, RequestContext)
+        assert isinstance(context, MessageContext)
         assert context.client_id == "client-1"
         assert request.method == "ping"
 
@@ -74,7 +74,7 @@ class TestRequestHandling:
         handler_called = False
 
         async def should_not_be_called(
-            context: RequestContext, request: ReadResourceRequest
+            context: MessageContext, request: ReadResourceRequest
         ) -> ReadResourceResult:
             nonlocal handler_called
             handler_called = True
@@ -129,7 +129,7 @@ class TestRequestHandling:
 
         # Arrange: Set up a handler that throws an exception
         async def failing_handler(
-            context: RequestContext, request: Request
+            context: MessageContext, request: Request
         ) -> EmptyResult:
             raise ValueError("Something went wrong in the handler")
 
@@ -168,7 +168,7 @@ class TestRequestHandling:
         handler_cancelled = False
 
         async def slow_handler(
-            context: RequestContext, request: Request
+            context: MessageContext, request: Request
         ) -> EmptyResult:
             nonlocal handler_cancelled
             handler_started.set()  # Signal that handler has started

--- a/tests/server/protocol/test_completion_manager.py
+++ b/tests/server/protocol/test_completion_manager.py
@@ -7,11 +7,11 @@ from conduit.protocol.completions import CompleteRequest, CompleteResult, Comple
 from conduit.protocol.initialization import ClientCapabilities, Implementation
 from conduit.protocol.prompts import PromptReference
 from conduit.server.client_manager import ClientState
+from conduit.server.message_context import MessageContext
 from conduit.server.protocol.completions import (
     CompletionManager,
     CompletionNotConfiguredError,
 )
-from conduit.server.request_context import RequestContext
 
 
 class TestCompletionManager:
@@ -25,7 +25,7 @@ class TestCompletionManager:
         )
         mock_client_manager = AsyncMock()
         mock_transport = AsyncMock()
-        self.context = RequestContext(
+        self.context = MessageContext(
             client_id=self.client_id,
             client_state=self.client_state,
             client_manager=mock_client_manager,

--- a/tests/server/protocol/test_logging_manager.py
+++ b/tests/server/protocol/test_logging_manager.py
@@ -5,8 +5,8 @@ from conduit.protocol.common import EmptyResult
 from conduit.protocol.initialization import ClientCapabilities, Implementation
 from conduit.protocol.logging import LoggingLevel, SetLevelRequest
 from conduit.server.client_manager import ClientState
+from conduit.server.message_context import MessageContext
 from conduit.server.protocol.logging import LoggingManager
-from conduit.server.request_context import RequestContext
 
 
 class TestLoggingManager:
@@ -24,7 +24,7 @@ class TestLoggingManager:
         )
         mock_client_manager = AsyncMock()
         mock_transport = AsyncMock()
-        self.context = RequestContext(
+        self.context = MessageContext(
             client_id=self.client_id,
             client_state=self.client_state,
             client_manager=mock_client_manager,

--- a/tests/server/protocol/test_prompt_manager.py
+++ b/tests/server/protocol/test_prompt_manager.py
@@ -12,8 +12,8 @@ from conduit.protocol.prompts import (
     Prompt,
 )
 from conduit.server.client_manager import ClientState
+from conduit.server.message_context import MessageContext
 from conduit.server.protocol.prompts import PromptManager
-from conduit.server.request_context import RequestContext
 
 
 class TestGlobalPromptManagement:
@@ -284,7 +284,7 @@ class TestProtocolHandlers:
         )
         mock_client_manager = AsyncMock()
         mock_transport = AsyncMock()
-        self.context = RequestContext(
+        self.context = MessageContext(
             client_id=self.client_id,
             client_state=self.client_state,
             client_manager=mock_client_manager,

--- a/tests/server/protocol/test_resource_handlers.py
+++ b/tests/server/protocol/test_resource_handlers.py
@@ -32,7 +32,6 @@ class TestHandleList:
         self.manager = ResourceManager()
         self.client_id = "test-client-123"
 
-        # Create a basic RequestContext for testing
         self.client_state = ClientState(
             capabilities=ClientCapabilities(),
             info=Implementation(name="test-client", version="1.0.0"),

--- a/tests/server/protocol/test_resource_handlers.py
+++ b/tests/server/protocol/test_resource_handlers.py
@@ -22,8 +22,8 @@ from conduit.protocol.resources import (
     UnsubscribeRequest,
 )
 from conduit.server.client_manager import ClientState
+from conduit.server.message_context import MessageContext
 from conduit.server.protocol.resources import ResourceManager
-from conduit.server.request_context import RequestContext
 
 
 class TestHandleList:
@@ -44,7 +44,7 @@ class TestHandleList:
         mock_client_manager = AsyncMock()
         mock_transport = AsyncMock()
 
-        self.context = RequestContext(
+        self.context = MessageContext(
             client_id=self.client_id,
             client_state=self.client_state,
             client_manager=mock_client_manager,
@@ -228,7 +228,7 @@ class TestHandleRead:
             initialized=True,
         )
 
-        self.context = RequestContext(
+        self.context = MessageContext(
             client_id=self.client_id,
             client_state=self.client_state,
             client_manager=mock_client_manager,
@@ -315,7 +315,7 @@ class TestHandleSubscription:
         )
         mock_client_manager = AsyncMock()
         mock_transport = AsyncMock()
-        self.context = RequestContext(
+        self.context = MessageContext(
             client_id=self.client_id,
             client_state=self.client_state,
             client_manager=mock_client_manager,

--- a/tests/server/protocol/test_tool_manager.py
+++ b/tests/server/protocol/test_tool_manager.py
@@ -326,7 +326,6 @@ class TestProtocolHandlers:
         self.manager = ToolManager()
         self.client_id = "test-client-123"
 
-        # Create a basic RequestContext for testing
         self.client_state = ClientState(
             capabilities=ClientCapabilities(),
             info=Implementation(name="test-client", version="1.0.0"),

--- a/tests/server/protocol/test_tool_manager.py
+++ b/tests/server/protocol/test_tool_manager.py
@@ -14,8 +14,8 @@ from conduit.protocol.tools import (
     Tool,
 )
 from conduit.server.client_manager import ClientState
+from conduit.server.message_context import MessageContext
 from conduit.server.protocol.tools import ToolManager
-from conduit.server.request_context import RequestContext
 
 
 class TestGlobalToolManagement:
@@ -338,7 +338,7 @@ class TestProtocolHandlers:
         mock_client_manager = AsyncMock()
         mock_transport = AsyncMock()
 
-        self.context = RequestContext(
+        self.context = MessageContext(
             client_id=self.client_id,
             client_state=self.client_state,
             client_manager=mock_client_manager,

--- a/tests/server/session/test_completion_handling.py
+++ b/tests/server/session/test_completion_handling.py
@@ -15,8 +15,8 @@ from conduit.protocol.completions import (
 from conduit.protocol.initialization import Implementation, ServerCapabilities
 from conduit.protocol.prompts import PromptReference
 from conduit.server.client_manager import ClientState
+from conduit.server.message_context import MessageContext
 from conduit.server.protocol.completions import CompletionNotConfiguredError
-from conduit.server.request_context import RequestContext
 from conduit.server.session import ServerConfig, ServerSession
 
 
@@ -44,7 +44,7 @@ class TestCompletionHandling:
             total=2,
             has_more=False,
         )
-        self.context = RequestContext(
+        self.context = MessageContext(
             client_id="test-client",
             client_state=ClientState(),
             client_manager=AsyncMock(),

--- a/tests/server/session/test_logging_handling.py
+++ b/tests/server/session/test_logging_handling.py
@@ -6,7 +6,7 @@ from conduit.protocol.common import EmptyResult
 from conduit.protocol.initialization import Implementation, ServerCapabilities
 from conduit.protocol.logging import SetLevelRequest
 from conduit.server.client_manager import ClientState
-from conduit.server.request_context import RequestContext
+from conduit.server.message_context import MessageContext
 from conduit.server.session import ServerConfig, ServerSession
 
 
@@ -26,7 +26,7 @@ class TestLoggingHandling:
             protocol_version=PROTOCOL_VERSION,
         )
         self.set_level_request = SetLevelRequest(level="info")
-        self.context = RequestContext(
+        self.context = MessageContext(
             client_id="test-client",
             client_state=ClientState(),
             client_manager=AsyncMock(),

--- a/tests/server/session/test_notification_handling.py
+++ b/tests/server/session/test_notification_handling.py
@@ -5,7 +5,7 @@ from conduit.protocol.common import CancelledNotification, ProgressNotification
 from conduit.protocol.initialization import Implementation, ServerCapabilities
 from conduit.protocol.roots import ListRootsResult, Root, RootsListChangedNotification
 from conduit.server.client_manager import ClientState
-from conduit.server.request_context import RequestContext
+from conduit.server.message_context import MessageContext
 from conduit.server.session import ServerConfig, ServerSession
 
 
@@ -19,7 +19,7 @@ class TestNotificationHandling:
             info=Implementation(name="test-server", version="1.0.0"),
             protocol_version=PROTOCOL_VERSION,
         )
-        self.context = RequestContext(
+        self.context = MessageContext(
             client_id="test-client",
             client_state=ClientState(),
             client_manager=AsyncMock(),

--- a/tests/server/session/test_prompt_handling.py
+++ b/tests/server/session/test_prompt_handling.py
@@ -20,7 +20,7 @@ from conduit.protocol.prompts import (
     PromptMessage,
 )
 from conduit.server.client_manager import ClientState
-from conduit.server.request_context import RequestContext
+from conduit.server.message_context import MessageContext
 from conduit.server.session import ServerConfig, ServerSession
 
 
@@ -39,7 +39,7 @@ class TestPromptHandling:
             info=Implementation(name="test-server", version="1.0.0"),
             protocol_version=PROTOCOL_VERSION,
         )
-        self.context = RequestContext(
+        self.context = MessageContext(
             client_id="test-client",
             client_state=ClientState(),
             client_manager=AsyncMock(),

--- a/tests/server/session/test_resource_handling.py
+++ b/tests/server/session/test_resource_handling.py
@@ -23,7 +23,7 @@ from conduit.protocol.resources import (
     UnsubscribeRequest,
 )
 from conduit.server.client_manager import ClientState
-from conduit.server.request_context import RequestContext
+from conduit.server.message_context import MessageContext
 from conduit.server.session import ServerConfig, ServerSession
 
 
@@ -58,7 +58,7 @@ class TestResourceHandling:
             info=Implementation(name="test-server", version="1.0.0"),
             protocol_version=PROTOCOL_VERSION,
         )
-        self.context = RequestContext(
+        self.context = MessageContext(
             client_id="test-client",
             client_state=ClientState(),
             client_manager=AsyncMock(),

--- a/tests/server/session/test_server_initialization.py
+++ b/tests/server/session/test_server_initialization.py
@@ -14,7 +14,7 @@ from conduit.protocol.initialization import (
     ServerCapabilities,
 )
 from conduit.server.client_manager import ClientState
-from conduit.server.request_context import RequestContext
+from conduit.server.message_context import MessageContext
 from conduit.server.session import ServerConfig, ServerSession
 
 
@@ -29,7 +29,7 @@ class TestInitialization:
         )
         self.session = ServerSession(self.transport, self.config)
 
-        self.context = RequestContext(
+        self.context = MessageContext(
             client_id="test-client",
             client_state=ClientState(),
             client_manager=AsyncMock(),

--- a/tests/server/session/test_tool_handling.py
+++ b/tests/server/session/test_tool_handling.py
@@ -14,7 +14,7 @@ from conduit.protocol.tools import (
     TextContent,
 )
 from conduit.server.client_manager import ClientState
-from conduit.server.request_context import RequestContext
+from conduit.server.message_context import MessageContext
 from conduit.server.session import ServerConfig, ServerSession
 
 
@@ -35,7 +35,7 @@ class TestToolHandling:
         )
 
         self.list_request = ListToolsRequest()
-        self.context = RequestContext(
+        self.context = MessageContext(
             client_id="test-client",
             client_state=ClientState(),
             client_manager=AsyncMock(),


### PR DESCRIPTION
## What changed?

Renamed `RequestContext` to `MessageContext` across both client and server sides. This includes updating the class names, file names (`request_context.py` → `message_context.py`), all imports, type signatures, and test references.

Closes #44

## Why?

The original name `RequestContext` was misleading since the context is used for both requests AND notifications. The class contains general client/server state and communication helpers, not request-specific data.

## Impact

- More honest and accurate naming that reflects actual usage
- No breaking changes to public APIs - this is purely internal refactoring
- Improved code clarity for future developers

## Testing

- All existing tests updated and passing
- No functional changes, only naming updates
- Verified comprehensive coverage with grep searches

## Review notes

This is a pure rename with no logic changes. The context object provides the same functionality, just with a name that accurately describes its purpose across all message types.

## Checklist

- [x] All new and old tests pass
- [x] Code follows our style guidelines
- [x] Documentation updated if needed
- [x] Breaking changes documented in commit messages